### PR TITLE
Make mail tab date parsing robust.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.0 (unreleased)
 ----------------
 
+- Make mail tab date parsing robust.
+  [jone]
+
 - Disable sorting in mail tab for header information columns.
   Sorting header informations does currently not work because
   the information is not in the catalog.

--- a/ftw/mail/mailtab.py
+++ b/ftw/mail/mailtab.py
@@ -1,9 +1,11 @@
 from DateTime import DateTime
+from DateTime.interfaces import SyntaxError
 from ftw.mail import _
 from ftw.tabbedview.browser import listing
 from ftw.table import helper
 from ftw.table.helper import readable_author
 from zope.i18n import translate
+import re
 
 
 def get_mail_header(field=None, isdate=False):
@@ -16,7 +18,12 @@ def get_mail_header(field=None, isdate=False):
         view = obj.restrictedTraverse('@@view')
 
         if isdate:
-            date = DateTime(view.get_header(field))
+            raw_date = view.get_header(field)
+            raw_date = re.sub(r'\((.*)\)', '\g<1>', raw_date)
+            try:
+                date = DateTime(raw_date)
+            except SyntaxError:
+                return ''
             return helper.readable_date_time_text(item, date)
 
         elif field == 'attachments':

--- a/ftw/mail/tests/builders.py
+++ b/ftw/mail/tests/builders.py
@@ -7,6 +7,8 @@ class MailBuilder(DexterityBuilder):
     portal_type = 'ftw.mail.mail'
 
     def with_message(self, data, contentType=u'message/rfc822', filename=u'message.eml'):
+        if isinstance(data, file):
+            data = data.read()
         self.arguments["message"] = NamedBlobFile(
             data=data, contentType=contentType, filename=filename)
         return self

--- a/ftw/mail/tests/mails/invalid_date.txt
+++ b/ftw/mail/tests/mails/invalid_date.txt
@@ -1,0 +1,10 @@
+MIME-Version: 1.0
+Content-Type: text/plain; charset="iso-8859-1"
+Content-Transfer-Encoding: quoted-printable
+To: =?iso-8859-1?q?Friedrich_H=F6lderlin?= <to@example.org>
+From: from@example.org
+Subject: =?iso-8859-1?q?Die_B=FCrgschaft?=
+Date: Wed, 28 Aug 2010 INVALID 18:50:04
+Message-Id: <1>
+
+Text

--- a/ftw/mail/tests/mails/time_zone_dates.txt
+++ b/ftw/mail/tests/mails/time_zone_dates.txt
@@ -1,0 +1,10 @@
+MIME-Version: 1.0
+Content-Type: text/plain; charset="iso-8859-1"
+Content-Transfer-Encoding: quoted-printable
+To: =?iso-8859-1?q?Friedrich_H=F6lderlin?= <to@example.org>
+From: from@example.org
+Subject: =?iso-8859-1?q?Die_B=FCrgschaft?=
+Date: Wed, 28 Aug 2010 18:50:04 +0200 (CEST)
+Message-Id: <1>
+
+Text

--- a/ftw/mail/tests/test_tab.py
+++ b/ftw/mail/tests/test_tab.py
@@ -1,7 +1,19 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.mail.testing import FTW_MAIL_FUNCTIONAL_TESTING
 from ftw.workspace.interfaces import IWorkspaceLayer
+from plone.registry.interfaces import IRegistry
 from unittest2 import TestCase
+from zope.component import getUtility
 from zope.interface import alsoProvides
+import json
+import os.path
+
+
+def mail_asset(name, ext='txt'):
+    tests_dir_path = os.path.dirname(__file__)
+    filename = '.'.join((name, ext))
+    return open(os.path.join(tests_dir_path, 'mails', filename))
 
 
 class TestMailTab(TestCase):
@@ -18,6 +30,30 @@ class TestMailTab(TestCase):
         view = self.portal.restrictedTraverse('tabbedview_view-mails')
 
         self.assertTrue(view, 'Mail tab is not available')
+
+    def test_mail_date_parsing(self):
+        create(Builder('mail').with_message(mail_asset('latin1')))
+        mail_row = self.get_mails_tab_data().get('rows')[0]
+        self.assertEquals('01.01.1970 01:00', mail_row.get('Date'))
+
+    def test_mail_invalid_date_results_in_empty_string(self):
+        create(Builder('mail').with_message(mail_asset('invalid_date')))
+        mail_row = self.get_mails_tab_data().get('rows')[0]
+        self.assertEquals('', mail_row.get('Date'))
+
+    def test_mail_date_parsing_with_time_zone(self):
+        create(Builder('mail').with_message(mail_asset('time_zone_dates')))
+        mail_row = self.get_mails_tab_data().get('rows')[0]
+        self.assertEquals('28.08.2010 18:50', mail_row.get('Date'))
+
+    def get_mails_tab_data(self):
+        request = self.portal.REQUEST
+        alsoProvides(request, IWorkspaceLayer)
+        registry = getUtility(IRegistry)
+        registry['ftw.tabbedview.interfaces.ITabbedView.extjs_enabled'] = True
+        request.form['tableType'] = 'extjs'
+        view = self.portal.restrictedTraverse('tabbedview_view-mails')
+        return json.loads(view())
 
 
 class TestNoMailTab(TestCase):


### PR DESCRIPTION
Example: Wed, 28 Aug 2010 18:50:04 +0200 (CEST)
This date lead to a SyntaxError.
1. Remove brackets, so that DateTime can parse this date
2. "Handle" SyntaxErrors by returng an empty string and skipping the date, so that the view does not raise exceptions.

@maethu please take a look
