### PR TITLE
Made primary field also working for dexterity installations.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
+- Made primary field also for dexterity-1 installations working.
+  [phgross]
+
 - Added French translation by I. Anthenien.
   [lknoepfel]
 

--- a/ftw/mail/mail.py
+++ b/ftw/mail/mail.py
@@ -11,6 +11,8 @@ from plone.dexterity.content import Item
 from plone.directives import form
 from plone.memoize import instance
 from plone.namedfile import field
+from plone.rfc822.interfaces import IPrimaryField
+from zope.interface import alsoProvides
 from zope.interface import implements
 import email
 
@@ -21,10 +23,14 @@ class IMail(form.Schema):
 
     form.primary('message')
     message = field.NamedBlobFile(
-        title = _(u"label_raw_message", default=u"Raw Message"),
-        description = _(u"help_raw_message", default=u""),
-        required = False,
+        title=_(u"label_raw_message", default=u"Raw Message"),
+        description=_(u"help_raw_message", default=u""),
+        required=False,
     )
+
+
+# necessary for dexterity 1 installations
+alsoProvides(IMail['message'], IPrimaryField)
 
 
 class Mail(Item):

--- a/ftw/mail/tests/test_mail.py
+++ b/ftw/mail/tests/test_mail.py
@@ -5,6 +5,7 @@ from ftw.mail.testing import FTW_MAIL_FUNCTIONAL_TESTING
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import setRoles
 from plone.dexterity.interfaces import IDexterityFTI
+from plone.rfc822.interfaces import IPrimaryFieldInfo
 from unittest2 import TestCase
 from zExceptions import NotFound
 from zope.component import createObject
@@ -88,6 +89,9 @@ class TestMailIntegration(TestCase):
         mail.title = "New Title"
         self.assertEquals(u'no_subject', mail.title)
 
+    def test_message_field_is_marked_as_primary_field(self):
+        mail = create(Builder('mail'))
+        self.assertEquals(IMail['message'], IPrimaryFieldInfo(mail).field)
 
     # def test_special(self):
     #     here = os.path.dirname(__file__)


### PR DESCRIPTION
The `message` field is correctly marked as a primary field for mail objects. 

But while ungroking the package, we broke the support for dexterity-1 installations. Because the `primary` directive only works in dexterity version 2 without grok. Therefore I add an additional alsoProvides statement. Which could be dropped, when dropping the dexterity-1 support.

@maethu could you take a look.
