### PR TITLE
Fix Upgrade-Step 2000: Only set a default for mail_domain, don't override existing values

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
+- Make sure only a *default* value will be set for IMailSettings.mail_domain,
+  but an existing value won't be overwritten when running the upgrade step twice.
+  [lgraf]
+
 - Fix From-/To-/Cc-Header encoding problem with Apple Mail.
   [jone]
 

--- a/ftw/mail/upgrades/profiles/2000/registry.xml
+++ b/ftw/mail/upgrades/profiles/2000/registry.xml
@@ -1,5 +1,3 @@
 <registry>
-    <records interface="ftw.mail.interfaces.IMailSettings">
-        <value key="mail_domain">example.org</value>
-    </records>
+    <records interface="ftw.mail.interfaces.IMailSettings" />
 </registry>


### PR DESCRIPTION
In upgrade step `2000`'s [`registry.xml`](https://github.com/4teamwork/ftw.mail/blob/master/ftw/mail/upgrades/profiles/2000/registry.xml#L3) a value is being set for `IMailSettings.mail_domain`:

``` xml
<registry>
    <records interface="ftw.mail.interfaces.IMailSettings">
        <value key="mail_domain">example.org</value>
    </records>
</registry>
```

This is an actual value, not a default value. Because the registry setting `ftw.mail.interfaces.IMailSettings` was introduced in `2000`, it will act as a default value most of the time, but it has a nasty side effect: If you for example migrate a mail_domain setting to the new `IMailSettings.mail_domain` of ftw.mail, and run the `ftw.mail` upgrade step twice, it will override any existing value with `example.org`.

The actual default is already defined on the [interface](https://github.com/4teamwork/ftw.mail/blob/master/ftw/mail/interfaces.py#L51):

```
    mail_domain = schema.TextLine(
        # ...
        default=u'example.org')
```
