### PR TITLE
Inbound: Remove acquisition wrapper when setting defaults

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
+- Inbound view: Adapt container as the context instead of content when
+  looking up default value adapter.
+  [lgraf]
+
 - Inbound view: Remove AQ wrapper when setting default values for newly
   created objects, in order to not get bogus results (due to acquisition)
   when checking whether a field is already present on the object.

--- a/ftw/mail/inbound.py
+++ b/ftw/mail/inbound.py
@@ -170,12 +170,12 @@ def createMailInContainer(container, message):
 
     newName = container._setObject(name, content)
     obj = container._getOb(newName)
-    obj = set_defaults(obj)
+    obj = set_defaults(obj, container)
     obj.reindexObject()
     return obj
 
 
-def set_defaults(obj):
+def set_defaults(obj, container):
     """set the default value for all fields on the mail object
     (including additional behaviors)"""
 
@@ -188,8 +188,8 @@ def set_defaults(obj):
                 # No value is set, so we try to set the default value
                 # otherwise we set the missing value
                 default = queryMultiAdapter((
-                        obj,
-                        obj.REQUEST,  # request
+                        container,
+                        container.REQUEST,  # request
                         None,  # form
                         field,
                         None,  # Widget


### PR DESCRIPTION
The check in [`ftw.mail.inbound.set_defaults()`](https://github.com/4teamwork/ftw.mail/blob/e58b53a78b4388a80d2827e0b727a0caeb98ab34/ftw/mail/inbound.py#L183) that's supposed to determine if a field is already present on the object currently doesn't work in all cases: If
- a schema's fields are stored using AttributeStorage
- the field is **not present** on the object itself
- but a field with the **same name** is present on a parent in the aq chain, 

the field's value will be acquired from that parent, wrongly indicating that the field is present on the object.

I therefore changed that check to use an object that isn't acquisition wrapped.

I also changed the lookup of the default value adapter to adapt the **container** as the context, instead of the content object itself. This is what the regular add form does.

/cc @buchi 
