### PR TITLE
SearchableTextExtender: Properly decode payloads in multipart messages  

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 2.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- SearchableTextExtender: Don't just decode the Content-Transfer-Encoding,
+  but also decode the actual content itself with the declared charset.
+  [lgraf]
 
 
 2.2.1 (2014-05-30)

--- a/ftw/mail/mail.py
+++ b/ftw/mail/mail.py
@@ -142,8 +142,23 @@ class SearchableTextExtender(object):
                 result = filter(None, result)
                 return ' '.join(result)
 
+            # Decode the Content-Transfer-Encoding (QP or base64)
+            payload_data = msg.get_payload(decode=True)
+
+            # Decode the actual content
+            charset = msg.get_content_charset()
+            if charset is not None:
+                payload_data = payload_data.decode(charset)
+            else:
+                # No content charset declared - decode with utf-8
+                # and hope for the best, ignoring any decoding errors
+                payload_data = payload_data.decode('utf-8', 'ignore')
+
+            # Finally encode it to UTF-8 (transforms require bytestrings)
+            payload_data = payload_data.encode('utf-8')
+
             result = transforms.convertTo('text/plain',
-                                          msg.get_payload(decode=True),
+                                          payload_data,
                                           mimetype=msg.get_content_type(),
                                           filename=msg.get_filename())
 

--- a/ftw/mail/profiles/default/metadata.xml
+++ b/ftw/mail/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>2100</version>
+    <version>2101</version>
     <dependencies>
         <dependency>profile-plone.app.dexterity:default</dependency>
         <dependency>profile-plone.app.registry:default</dependency>

--- a/ftw/mail/tests/mails/latin1_multipart.txt
+++ b/ftw/mail/tests/mails/latin1_multipart.txt
@@ -1,0 +1,24 @@
+Content-Type: multipart/alternative;
+ boundary="===============5151656922487848207=="
+MIME-Version: 1.0
+Subject: =?iso-8859-1?q?Sind_noch_B=FCror=E4ume_verf=FCgbar=3F?=
+From: from@example.org
+To: to@example.org
+
+--===============5151656922487848207==
+MIME-Version: 1.0
+Content-Type: text/plain; charset="iso8859-1"
+Content-Transfer-Encoding: base64
+
+SGFsbG8hClNpbmQgbm9jaCBC/HJvc3T8aGxlIHZvcmhhbmRlbj8=
+
+--===============5151656922487848207==
+MIME-Version: 1.0
+Content-Type: text/html; charset="iso8859-1"
+Content-Transfer-Encoding: base64
+
+PGh0bWw+CiAgPGhlYWQ+PC9oZWFkPgogIDxib2R5PgogICAgPHA+SGFsbG8hPGJyPgogICAgICAg
+U2luZCBub2NoIDxzdHJvbmc+Qvxyb3N0/GhsZTwvc3Ryb25nPiB2b3JoYW5kZW4/CiAgICA8L3A+
+CiAgPC9ib2R5Pgo8L2h0bWw+Cg==
+
+--===============5151656922487848207==--

--- a/ftw/mail/tests/test_searchabletext.py
+++ b/ftw/mail/tests/test_searchabletext.py
@@ -48,6 +48,12 @@ class TestSearchableText(TestCase):
         searchable_text = catalog_indexdata_of(mail)['SearchableText']
         self.assertIn('äöü', searchable_text)
 
+        # Now test with a latin1 encoded message part
+        mail = create(Builder('mail')
+                      .with_message(asset('latin1_multipart.txt')))
+        searchable_text = catalog_indexdata_of(mail)['SearchableText']
+        self.assertIn('b\xc3\xbcrost\xc3\xbchle', searchable_text)
+
     @skipUnless(getFSVersionTuple() >= (4, 3), "Plone >= 4.3")
     def test_umlauts_Plone_4_3_and_newer(self):
         # The text contains the umlauts "äöu", which is indexed
@@ -56,6 +62,12 @@ class TestSearchableText(TestCase):
                       .with_message(asset('attachment.txt')))
         searchable_text = catalog_indexdata_of(mail)['SearchableText']
         self.assertIn('aou', searchable_text)
+
+        # Now test with a latin1 encoded message part
+        mail = create(Builder('mail')
+                      .with_message(asset('latin1_multipart.txt')))
+        searchable_text = catalog_indexdata_of(mail)['SearchableText']
+        self.assertIn('burostuhle', searchable_text)
 
     def test_attached_email(self):
         mail = create(Builder('mail')

--- a/ftw/mail/upgrades/configure.zcml
+++ b/ftw/mail/upgrades/configure.zcml
@@ -52,4 +52,14 @@
         profile="ftw.mail:default"
         />
 
+    <!-- 2100 -> 2101 -->
+    <genericsetup:upgradeStep
+        title="Reindex mail searchable text with correctly decoded attachments"
+        description=""
+        source="2100"
+        destination="2101"
+        handler="ftw.mail.upgrades.to2101.ReindexSearchableText"
+        profile="ftw.mail:default"
+        />
+
 </configure>

--- a/ftw/mail/upgrades/to2101.py
+++ b/ftw/mail/upgrades/to2101.py
@@ -1,0 +1,8 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ReindexSearchableText(UpgradeStep):
+
+    def __call__(self):
+        self.catalog_reindex_objects({'portal_type': 'ftw.mail.mail'},
+                                     idxs=['SearchableText'])


### PR DESCRIPTION
Background:

When composing a mail containing non-ASCII characters, first the content needs to be encoded using a charset like `utf-8` or `latin-1`. This encoding is declared as a parameter for the `Content-Type` header (either in the message headers, or in the part headers of a multipart message:

`Content-Type: text/plain; charset="iso8859-1"`

This will make sure all unicode characters are correctly encoded to an 8-bit bytestream. However, SMTP only allows 7-bit ASCII, so before sending the message, the encoded bytes need to be encoded once again to comply with the 7-bit restriction: This encoding layer is the `Content-Transfer-Encoding`, and it is either quoted printable or base64.

In the change introduced in PR #14 only the `Content-Transfer-Encoding` layer gets decoded, but the actual payload contents are still encoded in whatever character sets the sender used. So that charset happens to be `utf-8` it works, but otherwise the `SearchableText` will be mangled if a non-UTF8 string is passed to the catalog for indexing.

So this pull-request reads out the `content_charset`, and, if present, decodes the payload content using that charset. If no `content_charset` is given, that part of a multipart message usually only contains headers, no body. In that case, we'll assume `utf-8` and decode using `errors='ignore'`.

Also see [this talk](https://www.youtube.com/watch?v=JENdgiAPD6c) for the two different encoding mechanisms.

@jone please review.
/cc @buchi 
