### PR TITLE
SearchableTextExtender: Gracefully handle mails with incorrectly declared charset

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 2.2.2 (unreleased)
 ------------------
 
+- SearchableTextExtender: For mails with incorrectly declared charset,
+  try decoding them as latin1 as a last resort, ignoring all errors.
+  [lgraf]
+
 - SearchableTextExtender: Don't just decode the Content-Transfer-Encoding,
   but also decode the actual content itself with the declared charset.
   [lgraf]

--- a/ftw/mail/mail.py
+++ b/ftw/mail/mail.py
@@ -148,7 +148,12 @@ class SearchableTextExtender(object):
             # Decode the actual content
             charset = msg.get_content_charset()
             if charset is not None:
-                payload_data = payload_data.decode(charset)
+                try:
+                    payload_data = payload_data.decode(charset)
+                except UnicodeDecodeError:
+                    # Wrong charset declared. Try decoding with latin1
+                    # as a last resort, and ignore any errors
+                    payload_data = payload_data.decode('latin1', 'ignore')
             else:
                 # No content charset declared - decode with utf-8
                 # and hope for the best, ignoring any decoding errors


### PR DESCRIPTION
For mails with incorrectly declared attachments, try decoding them as latin1 as a last resort, ignoring all errors.

(Example: `utf-8` declared, but part is actually encoded as `latin1`)

/cc @phgross @jone @buchi
