### PR TITLE
Enable referenceablebehavior for mails

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.2.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Enable referencablebehavior for mails.
+  [jone]
 
 
 2.2.3 (2014-10-24)

--- a/ftw/mail/configure.zcml
+++ b/ftw/mail/configure.zcml
@@ -7,7 +7,6 @@
     i18n_domain="ftw.mail">
 
     <include file="permissions.zcml" />
-    <include package=".upgrades" />
 
 	<i18n:registerTranslations directory="locales" />
 
@@ -24,6 +23,7 @@
         directory="profiles/default"
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
+    <include package=".upgrades" />
 
 
     <!-- Attachment view -->

--- a/ftw/mail/profiles/default/metadata.xml
+++ b/ftw/mail/profiles/default/metadata.xml
@@ -1,5 +1,4 @@
 <metadata>
-    <version>2101</version>
     <dependencies>
         <dependency>profile-plone.app.dexterity:default</dependency>
         <dependency>profile-plone.app.registry:default</dependency>

--- a/ftw/mail/profiles/default/types/ftw.mail.mail.xml
+++ b/ftw/mail/profiles/default/types/ftw.mail.mail.xml
@@ -25,6 +25,7 @@
   <property name="behaviors">
     <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
     <element value="plone.app.content.interfaces.INameFromTitle" />
+    <element value="plone.app.referenceablebehavior.referenceable.IReferenceable" />
   </property>
 
   <!-- View information -->

--- a/ftw/mail/tests/test_mail.py
+++ b/ftw/mail/tests/test_mail.py
@@ -2,11 +2,12 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.mail.mail import IMail
 from ftw.mail.testing import FTW_MAIL_FUNCTIONAL_TESTING
-from plone.app.testing import TEST_USER_ID
 from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.namedfile import NamedBlobFile
 from plone.rfc822.interfaces import IPrimaryFieldInfo
+from plone.uuid.interfaces import IUUID
 from unittest2 import TestCase
 from zExceptions import NotFound
 from zope.component import createObject
@@ -140,6 +141,11 @@ class TestMailIntegration(TestCase):
             filename=u'message.eml')
         self.assertEquals('Die B\xc3\xbcrgschaft',
                           mail.get_header('Subject'))
+
+    def test_referenceing_mails_from_archetypes_objects(self):
+        mail = create(Builder('mail'))
+        page = create(Builder('page').having(relatedItems=[IUUID(mail)]))
+        self.assertTrue(page)
 
     # def test_special(self):
     #     here = os.path.dirname(__file__)

--- a/ftw/mail/upgrades/20150227185742_add_referenceablebehavior/types/ftw.mail.mail.xml
+++ b/ftw/mail/upgrades/20150227185742_add_referenceablebehavior/types/ftw.mail.mail.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="ftw.mail.mail">
+
+    <property name="behaviors" purge="False">
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable" />
+    </property>
+
+</object>

--- a/ftw/mail/upgrades/20150227185742_add_referenceablebehavior/upgrade.py
+++ b/ftw/mail/upgrades/20150227185742_add_referenceablebehavior/upgrade.py
@@ -1,0 +1,14 @@
+from ftw.upgrade import UpgradeStep
+from Products.Archetypes import config
+
+
+class AddReferenceablebehavior(UpgradeStep):
+    """Add referenceablebehavior.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        msg = 'Update UID catalog after enabling referenceablebehavior on mails.'
+        uidcatalog = self.getToolByName(config.UID_CATALOG)
+        for mail in self.objects({'portal_type': 'ftw.mail.mail'}, msg):
+            uidcatalog.catalog_object(mail, '/'.join(mail.getPhysicalPath()))

--- a/ftw/mail/upgrades/configure.zcml
+++ b/ftw/mail/upgrades/configure.zcml
@@ -1,6 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
     i18n_domain="ftw.mail">
 
     <!-- 1 -> 2000 -->
@@ -60,6 +61,12 @@
         destination="2101"
         handler="ftw.mail.upgrades.to2101.ReindexSearchableText"
         profile="ftw.mail:default"
+        />
+
+    <include package="ftw.upgrade" file="meta.zcml" />
+    <upgrade-step:directory
+        profile="ftw.mail:default"
+        directory="."
         />
 
 </configure>

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(name='ftw.mail',
         'collective.autopermission',
         'collective.dexteritytextindexer',
         'plone.directives.form',
-        'ftw.upgrade',
+        'ftw.upgrade >= 1.11.0',
         'premailer',
         ],
 

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(name='ftw.mail',
 
       install_requires=[
         'plone.api',
+        'plone.app.referenceablebehavior',
         'plone.registry',
         'plone.dexterity',
         'setuptools',


### PR DESCRIPTION
Adds the [plone.app.referenceablebehavior](https://pypi.python.org/pypi/plone.app.referenceablebehavior) on mails so that they can be references from Archetypes objects.

We could also do that in integration packages for sites where Dexterity and Archetypes objects are mixed, but I don't think that disturbs a lot here..

/ @maethu @lukasgraf 