### PR TITLE
Refactor mail view to include all HTML parts.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Refactor mail view to include all HTML parts.
+  [jone]
 
 
 2.3.0 (2015-03-02)

--- a/ftw/mail/mail_templates/view.pt
+++ b/ftw/mail/mail_templates/view.pt
@@ -52,7 +52,7 @@
 
         <div tal:replace="structure provider:plone.abovecontentbody" />
 
-        <div tal:replace="structure view/html_safe_body">Body</div>
+        <div tal:content="structure view/html_safe_body" class="mailBody">Body</div>
 
         <tal:attachments condition="view/attachments">
         <h2 i18n:translate="">Attachments</h2>

--- a/ftw/mail/tests/mails/multiple_html_parts.txt
+++ b/ftw/mail/tests/mails/multiple_html_parts.txt
@@ -1,0 +1,27 @@
+From: John Doe <john@doe.come>
+Content-Type: multipart/alternative;
+	boundary="Apple-Mail=_C5D1E5D9-0F1E-429C-98AD-D70C669BF5ED"
+Subject: multiple html parts
+Date: Wed, 11 Mar 2015 15:27:25 +0100
+To: john@doe.com
+
+--Apple-Mail=_C5D1E5D9-0F1E-429C-98AD-D70C669BF5ED
+Content-Type: multipart/mixed;
+	boundary="Apple-Mail=_89845EDF-F75F-44FC-A9E3-69A4A41E5539"
+
+--Apple-Mail=_89845EDF-F75F-44FC-A9E3-69A4A41E5539
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/html;
+	charset=utf-8
+
+<html><head><meta http-equiv="Content-Type" content="text/html charset=us-ascii"></head><body style="word-wrap: break-word; -webkit-nbsp-mode: space; -webkit-line-break: after-white-space;" class=""><div class="">Hello</div></body></html>
+
+--Apple-Mail=_89845EDF-F75F-44FC-A9E3-69A4A41E5539
+Content-Transfer-Encoding: 7bit
+Content-Type: text/html;
+	charset=us-ascii
+
+<html><head><meta http-equiv="Content-Type" content="text/html charset=us-ascii"></head><body style="word-wrap: break-word; -webkit-nbsp-mode: space; -webkit-line-break: after-white-space;" class=""><div class="">World</div></body></html>
+--Apple-Mail=_89845EDF-F75F-44FC-A9E3-69A4A41E5539--
+
+--Apple-Mail=_C5D1E5D9-0F1E-429C-98AD-D70C669BF5ED--

--- a/ftw/mail/tests/test_mail.py
+++ b/ftw/mail/tests/test_mail.py
@@ -93,7 +93,7 @@ class TestMailIntegration(TestCase):
         view()
 
         self.assertEquals('', view.get_header('Subject'))
-        self.assertEquals('<div class="mailBody"></div>', view.body())
+        self.assertEquals('', view.html_safe_body())
 
     def test_attachments(self):
         mail = create(Builder('mail')

--- a/ftw/mail/tests/test_mail_view.py
+++ b/ftw/mail/tests/test_mail_view.py
@@ -98,6 +98,15 @@ class TestMailView(TestCase):
                          "Javascript gets not removed by the mail view.")
 
     @browsing
+    def test_mail_body_contains_all_html_parts(self, browser):
+        """Regression:
+        """
+        mail = create(Builder('mail').with_message(mail_asset('multiple_html_parts')))
+        browser.login().visit(mail)
+        self.assertEquals('Hello World',
+                          browser.css('.mailBody').first.text)
+
+    @browsing
     def test_style_blocks_get_parsed(self, browser):
         mail = create(Builder('mail').with_message(mail_asset('xxs_mail')))
         browser.login().visit(mail)

--- a/ftw/mail/tests/test_utils.py
+++ b/ftw/mail/tests/test_utils.py
@@ -29,6 +29,8 @@ class TestUtils(unittest2.TestCase):
         msg_txt = open(os.path.join(here, 'mails', 'nested_referenced_image_attachment.txt'),
                        'r').read()
         self.nested_referenced_image_attachment = email.message_from_string(msg_txt)
+        msg_txt = open(os.path.join(here, 'mails', 'multiple_html_parts.txt'), 'r').read()
+        self.msg_multiple_html_parts = email.message_from_string(msg_txt)
 
     def test_get_header(self):
         self.assertEquals('', utils.get_header(self.msg_empty, 'Subject'))
@@ -73,8 +75,16 @@ class TestUtils(unittest2.TestCase):
         self.assertEquals(1, len(utils.get_text_payloads(self.msg_ascii)))
 
     def test_get_body(self):
-        self.assertEquals('', utils.get_body(self.msg_empty))
-        self.assertEquals('<p>Lorem ipsum', utils.get_body(self.msg_ascii)[:14])
+        self.assertEquals(0, len(utils.get_body(self.msg_empty)))
+        self.assertEquals('<p>Lorem ipsum', utils.get_body(self.msg_ascii)[0][:14])
+
+    def test_get_body_returns_each_html_document_separately(self):
+        parts = utils.get_body(self.msg_multiple_html_parts)
+        self.assertEquals(2, len(parts), 'Expected two html parts.')
+        first, second = parts
+
+        self.assertIn('Hello', first)
+        self.assertIn('World', second)
 
     def test_get_filename(self):
         msg_txt = \

--- a/ftw/mail/utils.py
+++ b/ftw/mail/utils.py
@@ -90,12 +90,10 @@ def get_payload(msg):
 def get_body(msg, url_prefix=''):
     """Returns the mail body as HTML string. All text parts of a multipart
     message are returned."""
-    html = ''
-    parts = get_text_payloads(msg)
-    for part in parts:
-        html += part
-    html = adjust_image_tags(html, msg, url_prefix)
-    return html
+    result = []
+    for part in get_text_payloads(msg):
+        result.append(adjust_image_tags(part, msg, url_prefix))
+    return result
 
 
 def get_attachments(msg):


### PR DESCRIPTION
When a mail has inline attachments, we may have two surrounding HTML parts.
Those parts are complete HTML documents (with <html> tag etc), which broke the rendering so that only the last part was rendered.

We still consume all HTML parts but extract the body and make them safe separately, so that we only merge partials.

Inline attachments are still not positioned at the right position but below in a list of attachments, which is okay.

@lukasgraf could you review this one?
/cc @phgross @buchi 