### PR TITLE
Don't remove quotes from header parts that need them

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 2.3.2 (unreleased)
 ------------------
 
+- Make RegEx for Apple Partial Encoding regex more specific so we don't
+  accidentally remove quotes around header parts that need them.
+  [lgraf]
+
 - Added test for zip export.
   [lknoepfel]
 

--- a/ftw/mail/tests/mails/from_header_with_quotes.txt
+++ b/ftw/mail/tests/mails/from_header_with_quotes.txt
@@ -1,0 +1,20 @@
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf8"
+Content-Transfer-Encoding: base64
+To: =?utf-8?q?Friedrich_H=C3=B6lderlin?= <to@example.org>
+From: "Mueller-Valser, Gabriela" <gabriela.mueller@example.org>
+Subject: =?utf-8?q?Die_B=C3=BCrgschaft?=
+Date: Thu, 01 Jan 1970 01:00:00 +0100
+Message-Id: <1>
+X-Mailer: Zope/SecureMailHost
+
+RGllIELDvHJnc2NoYWZ0CkZyaWVkcmljaCBTY2hpbGxlcgoKWnUgRGlvbnlzLCBkZW0gVHlyYW5u
+ZW4sIHNjaGxpY2gKRGFtb24sIGRlbiBEb2xjaCBpbSBHZXdhbmRlOgpJaG4gc2NobHVnZW4gZGll
+IEjDpHNjaGVyIGluIEJhbmRlLArCu1dhcyB3b2xsdGVzdCBkdSBtaXQgZGVtIERvbGNoZT8gc3By
+aWNoIcKrCkVudGdlZ25ldCBpaG0gZmluc3RlciBkZXIgV8O8dGVyaWNoLgrCu0RpZSBTdGFkdCB2
+b20gVHlyYW5uZW4gYmVmcmVpZW4hwqsKwrtEYXMgc29sbHN0IGR1IGFtIEtyZXV6ZSBiZXJldWVu
+LsKrCgrCu0ljaCBiaW7Cqywgc3ByaWNodCBqZW5lciwgwrt6dSBzdGVyYmVuIGJlcmVpdApVbmQg
+Yml0dGUgbmljaHQgdW0gbWVpbiBMZWJlbjoKRG9jaCB3aWxsc3QgZHUgR25hZGUgbWlyIGdlYmVu
+LApJY2ggZmxlaGUgZGljaCB1bSBkcmVpIFRhZ2UgWmVpdCwKQmlzIGljaCBkaWUgU2Nod2VzdGVy
+IGRlbSBHYXR0ZW4gZ2VmcmVpdDsKSWNoIGxhc3NlIGRlbiBGcmV1bmQgZGlyIGFscyBCw7xyZ2Vu
+LApJaG4gbWFnc3QgZHUsIGVudHJpbm4nIGljaCwgZXJ3w7xyZ2VuLsKrCg==

--- a/ftw/mail/tests/test_utils.py
+++ b/ftw/mail/tests/test_utils.py
@@ -31,6 +31,8 @@ class TestUtils(unittest2.TestCase):
         self.nested_referenced_image_attachment = email.message_from_string(msg_txt)
         msg_txt = open(os.path.join(here, 'mails', 'multiple_html_parts.txt'), 'r').read()
         self.msg_multiple_html_parts = email.message_from_string(msg_txt)
+        msg_txt = open(os.path.join(here, 'mails', 'from_header_with_quotes.txt'), 'r').read()
+        self.from_header_with_quotes = email.message_from_string(msg_txt)
 
     def test_get_header(self):
         self.assertEquals('', utils.get_header(self.msg_empty, 'Subject'))
@@ -44,6 +46,15 @@ class TestUtils(unittest2.TestCase):
                           utils.get_header(self.msg_utf8, 'Subject'))
         self.assertEquals('Friedrich H\xc3\xb6lderlin <to@example.org>',
                           utils.get_header(self.msg_utf8, 'To'))
+
+    def test_get_from_header_with_quotes(self):
+        self.assertEquals(
+            '"Mueller-Valser, Gabriela" <gabriela.mueller@example.org>',
+            self.from_header_with_quotes['From'])
+
+        self.assertEquals(
+            '"Mueller-Valser, Gabriela" <gabriela.mueller@example.org>',
+            utils.get_header(self.from_header_with_quotes, 'From'))
 
     def test_get_date_header(self):
         # a date header

--- a/ftw/mail/utils.py
+++ b/ftw/mail/utils.py
@@ -10,7 +10,7 @@ import re
 # a regular expression that matches src attributes of img tags containing a cid
 IMG_SRC_RE = re.compile(r'<img[^>]*?src="cid:([^"]*)', re.IGNORECASE|re.DOTALL)
 BODY_RE = re.compile(r'<body>(.*)</body>', re.IGNORECASE|re.DOTALL)
-APPLE_PARTIAL_ENCODING_RE = re.compile(r'^"(.*)"( <.*>)$')
+APPLE_PARTIAL_ENCODING_RE = re.compile(r'^"(.*=\?.*\?=.*)"( <.*>)$')
 
 
 def safe_decode_header(value):


### PR DESCRIPTION
Example:
For the following From Header `"Mueller-Valser, Gabriela" <gabriela.mueller@example.org>` the `safe_decode_header` returns `Mueller-Valser, Gabriela <gabriela.mueller@example.org>`  

The problem is the regex used for the [apple partial encoding fix](https://github.com/4teamwork/ftw.mail/blob/master/ftw/mail/utils.py#L36-38).

Reproducing Test [Branch](https://github.com/4teamwork/ftw.mail/commits/pg_get_from_header_bug), f3a6f55be5105a021607454ff1483bf2c12733ee
