### PR TITLE
get_header(): Fix up RFC 2047 encoded words separated by 'CRLF LWSP'

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,12 @@ Changelog
 2.3.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- get_header(): Fix up RFC 2047 encoded words separated by 'CRLF LWSP'
+  (which is fine according to the RFC) by replacing the CRLF with a
+  SPACE so decode_header can parse them correctly.
+  This works around a bug in decode_header that has been fixed in 3.3.
+  See http://bugs.python.org/issue4491 and its duplicate.
+  [lgraf]
 
 
 2.3.2 (2015-06-30)

--- a/ftw/mail/tests/mails/encoded_word_without_lwsp.txt
+++ b/ftw/mail/tests/mails/encoded_word_without_lwsp.txt
@@ -1,0 +1,26 @@
+MIME-Version: 1.0
+Content-Type: text/plain; charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+To: =?utf-8?Q?B=C3=A4rengraben?=
+ <to@example.org>
+From: =?utf-8?Q?B=C3=A4rengraben?=
+ =?utf-8?Q?B=C3=A4rengraben?=
+ <from@example.org>
+Subject: Lorem Ipsum
+Date: Thu, 01 Jan 1970 01:00:00 +0100
+Message-Id: <1>
+
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit,
+sed diam nonummy nibh euismod tincidunt ut laoreet dolore
+magna aliquam erat volutpat. Ut wisi enim ad minim veniam,
+quis nostrud exerci tation ullamcorper suscipit lobortis
+nisl ut aliquip ex ea commodo consequat.
+
+Duis autem vel eum iriure dolor in hendrerit in vulputate 
+velit esse molestie consequat, vel illum dolore eu feugiat
+nulla facilisis at vero eros et accumsan et iusto odio
+dignissim qui blandit praesent luptatum zzril delenit augue
+duis dolore te feugait nulla facilisi.Lorem ipsum dolor sit 
+amet, consectetuer adipiscing elit, sed diam nonummy nibh
+euismod tincidunt ut laoreet dolore magna aliquam erat 
+volutpat.

--- a/ftw/mail/tests/test_utils.py
+++ b/ftw/mail/tests/test_utils.py
@@ -33,6 +33,8 @@ class TestUtils(unittest2.TestCase):
         self.msg_multiple_html_parts = email.message_from_string(msg_txt)
         msg_txt = open(os.path.join(here, 'mails', 'from_header_with_quotes.txt'), 'r').read()
         self.from_header_with_quotes = email.message_from_string(msg_txt)
+        msg_txt = open(os.path.join(here, 'mails', 'encoded_word_without_lwsp.txt'), 'r').read()
+        self.encoded_word_without_lwsp = email.message_from_string(msg_txt)
 
     def test_get_header(self):
         self.assertEquals('', utils.get_header(self.msg_empty, 'Subject'))
@@ -55,6 +57,16 @@ class TestUtils(unittest2.TestCase):
         self.assertEquals(
             '"Mueller-Valser, Gabriela" <gabriela.mueller@example.org>',
             utils.get_header(self.from_header_with_quotes, 'From'))
+
+    def test_get_header_fixes_encoded_words_without_lwsp(self):
+        self.assertEquals(
+            'B\xc3\xa4rengraben <to@example.org>',
+            utils.get_header(self.encoded_word_without_lwsp, 'To'))
+
+        # Should not insert additional whitespace between encoded words
+        self.assertEquals(
+            'B\xc3\xa4rengrabenB\xc3\xa4rengraben <from@example.org>',
+            utils.get_header(self.encoded_word_without_lwsp, 'From'))
 
     def test_get_date_header(self):
         # a date header


### PR DESCRIPTION
This PR adds a fix / workaround for a bug in Python's `decode_header()` when parsing headers with encoded words.

---

`encoded-words` as defined by [RFC 2047](https://tools.ietf.org/html/rfc2047) are atoms that are used to encode strings with non-ASCII characters in RFC 822 header fields. They look like this: `=?utf-8?Q?B=C3=A4rengraben?=`

In header fields, multiple encoded words may occur, and they may be mixed with regular non-encoded ASCII text. All those items are atoms that need to be separated by `linear-white-space` according to [RFC2047 Section 5](https://tools.ietf.org/html/rfc2047#section-5):

> Ordinary ASCII text and 'encoded-word's may appear together in the same header field.  However, an 'encoded-word' that appears in a header field defined as '*text' MUST be separated from any adjacent 'encoded-word' or 'text' by 'linear-white-space'.

`linear-white-space` is defined in [RFC 822](https://tools.ietf.org/html/rfc822#section-3.3):

```
CRLF        =  CR LF
LWSP-char   =  SPACE / HTAB
linear-white-space =  1*([CRLF] LWSP-char)
```

So a header field like this is perfectly fine according to the RFC:
```
From: =?utf-8?Q?B=C3=A4rengraben?=\r\n <from@example.org>
```

However, Python's `email.header.decode_header()` function can't handle this properly, which is a bug that has been fixed in Python 3.3. See Python issue [#4491](http://bugs.python.org/issue4491) for this exact case, and the duplicate [#1079](http://bugs.python.org/issue1079) for the more general case.

This PR therefore fixes up header lines that match this particular pattern by replacing the CRLF with a SPACE before having them parsed by `decode_header()`.

@phgross @deiferni 
/cc @buchi @jone 
