### PR TITLE
Make sure message.contentType is stored as `str`, not `unicode`.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 2.3.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make sure message.contentType is stored as `str`, not `unicode`. Otherwise
+  this will result in "Wrong contained type" when trying to save the object
+  again. Includes Upgrade-Step to fix existing objects.
+  [lgraf]
 
 
 2.3.3 (2015-08-03)

--- a/ftw/mail/inbound.py
+++ b/ftw/mail/inbound.py
@@ -142,7 +142,7 @@ def createMailInContainer(container, message):
     schema = fti.lookupSchema()
     field_type = getFields(schema)['message']._type
     message_value = field_type(data=message,
-                       contentType=u'message/rfc822', filename=u'message.eml')
+                       contentType='message/rfc822', filename=u'message.eml')
     # create mail object
     content = createContent('ftw.mail.mail', message=message_value)
 

--- a/ftw/mail/upgrades/20150810100822_fix_message_content_type/upgrade.py
+++ b/ftw/mail/upgrades/20150810100822_fix_message_content_type/upgrade.py
@@ -1,0 +1,16 @@
+from ftw.upgrade import UpgradeStep
+
+
+class FixMessageContentType(UpgradeStep):
+    """Fix type of the NamedBlobFile's `contentType` attribute (unicode -> str)
+
+    ftw.mail's `createMailInContainer` function previously set it to unicode,
+    but it should be string.
+    """
+
+    def __call__(self):
+        for obj in self.objects({'portal_type': 'ftw.mail.mail'},
+                                'Fix message.contentType (unicode -> str)'):
+            message = obj.message
+            if isinstance(message.contentType, unicode):
+                message.contentType = message.contentType.encode('ascii')


### PR DESCRIPTION
Otherwise this will result in `Wrong contained type` when trying to save the object again. Includes Upgrade-Step to fix existing objects.

@deiferni @jone 