### PR TITLE
sort mails by receptiontime.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.3.4 (unreleased)
 ------------------
 
+- Sort Mailtab so the newest Mail is the first Item.
+  [tschanzt]
+
 - Make sure message.contentType is stored as `str`, not `unicode`. Otherwise
   this will result in "Wrong contained type" when trying to save the object
   again. Includes Upgrade-Step to fix existing objects.

--- a/ftw/mail/mailtab.py
+++ b/ftw/mail/mailtab.py
@@ -46,8 +46,8 @@ class MailsTab(listing.CatalogListingView):
 
     types = ('ftw.mail.mail',)
 
-    sort_on = 'modified'
-
+    sort_on = 'Date'
+    sort_reverse = True
     show_selects = False
     show_menu = False
 


### PR DESCRIPTION
@jone The mailtab is now sorted by receptiondate. The newest on top.