### PR TITLE
Make upgrade step to fix `message.contentType` more defensive

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 2.3.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make upgrade step to fix `message.contentType` more defensive to avoid
+  trouble during upgrades caused by caching weirdness.
+  [lgraf]
 
 
 2.3.4 (2015-08-19)


### PR DESCRIPTION
Make upgrade step to fix `message.contentType` more defensive to avoid trouble during upgrades caused by caching weirdness (for example: `obj.message` returning `None` even though a message should have been set).

@phgross 
