### PR TITLE
Fix broken <meta /> tags in HTML MIME parts.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.3.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix broken <meta /> tags in text/html MIME parts.
+  [lgraf]
 
 
 2.3.6 (2015-09-02)

--- a/ftw/mail/mail.py
+++ b/ftw/mail/mail.py
@@ -228,6 +228,7 @@ class View(BrowserView):
         result = []
         for body in parts:
             body = self.rewrite_css_styles(body)
+            body = utils.fix_broken_meta_tags(body)
             body = utils.unwrap_html_body(body, 'mailBody-part')
             body = self.transfrom_safe_html(body)
             result.append(body)

--- a/ftw/mail/tests/mails/broken_meta_tags.txt
+++ b/ftw/mail/tests/mails/broken_meta_tags.txt
@@ -1,0 +1,57 @@
+MIME-Version: 1.0
+To: to@example.org
+From: from@example.org
+Subject: Lorem Ipsum
+Date: Thu, 01 Jan 1970 01:00:00 +0100
+Message-Id: <1>
+X-MS-Has-Attach: yes
+X-MS-TNEF-Correlator: 
+x-mailer: Apple Mail (2.2104)
+Content-Type: multipart/mixed;
+ boundary="_007_868CB2E9786D41568D602026CBE426A4maccom_"
+MIME-Version: 1.0
+
+--_007_868CB2E9786D41568D602026CBE426A4maccom_
+Content-Type: multipart/alternative;
+ boundary="_000_868CB2E9786D41568D602026CBE426A4maccom_"
+
+--_000_868CB2E9786D41568D602026CBE426A4maccom_
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: base64
+
+VGhpcyBpcyBzb21lIGJvZHkgdGV4dC4KTG9yZW0gSXBzdW0K
+
+--_000_868CB2E9786D41568D602026CBE426A4maccom_--
+
+--_007_868CB2E9786D41568D602026CBE426A4maccom_
+Content-Type: text/html; name="ATT00001.htm"
+Content-Description: ATT00001.htm
+Content-Disposition: attachment; filename="ATT00001.htm"; size=256;
+ creation-date="Thu, 03 Sep 2015 13:45:33 GMT";
+ modification-date="Thu, 03 Sep 2015 13:45:33 GMT"
+Content-ID: <3D7D5E40C59CE643A0AC663C09D436A7@example.org>
+Content-Transfer-Encoding: base64
+
+PGh0bWw+PGJvZHkgc3R5bGU9IndvcmQtd3JhcDogYnJlYWstd29yZDsgLXdlYmtpdC1uYnNwLW1v
+ZGU6IHNwYWNlOyAtd2Via2l0LWxpbmUtYnJlYWs6IGFmdGVyLXdoaXRlLXNwYWNlOyI+PGhlYWQ+
+PG1ldGEgaHR0cC1lcXVpdj0iQ29udGVudC1UeXBlIiBjb250ZW50PSJ0ZXh0L2h0bWwgY2hhcnNl
+dD11cy1hc2NpaSI+PC9oZWFkPjxkaXYgY2xhc3M9IkFwcGxlT3JpZ2luYWxDb250ZW50cyI+PGRp
+dj48L2Rpdj48L2Rpdj48L2JvZHk+PC9odG1sPg==
+
+--_007_868CB2E9786D41568D602026CBE426A4maccom_
+Content-Type: text/html; charset=iso-8859-1; name="ATT00002.htm"
+Content-Description: ATT00002.htm
+Content-Disposition: attachment; filename="ATT00002.htm"; size=315;
+ creation-date="Thu, 03 Sep 2015 13:45:33 GMT";
+ modification-date="Thu, 03 Sep 2015 13:45:33 GMT"
+Content-ID: <C75E167065D32849A2172F84F74A0A25@example.org>
+Content-Transfer-Encoding: base64
+
+JzxodG1sPjxoZWFkPjxtZXRhIGh0dHAtZXF1aXY9IkNvbnRlbnQtVHlwZSIgY29udGVudD0idGV4
+dC9odG1sIGNoYXJzZXQ9aXNvLTg4NTktMSI+PC9oZWFkPjxib2R5IHN0eWxlPSJ3b3JkLXdyYXA6
+IGJyZWFrLXdvcmQ7IC13ZWJraXQtbmJzcC1tb2RlOiBzcGFjZTsgLXdlYmtpdC1saW5lLWJyZWFr
+OiBhZnRlci13aGl0ZS1zcGFjZTsiIGNsYXNzPSIiPjxkaXY+PGRpdiBjbGFzcz0iIj48cD5UaGlz
+IGlzIHNvbWUgdGV4dCB3aXRoIFVtbGF1dHMgLSBC5HJlbmdyYWJlbiAtIHNlZT88L2Rpdj48L2Rp
+dj48YnIgY2xhc3M9IiI+PC9ib2R5PjwvaHRtbD4n
+
+--_007_868CB2E9786D41568D602026CBE426A4maccom_--


### PR DESCRIPTION
`text/html` MIME parts of a multipart message may include `<meta />` tags that declare a **charset that differs from the encoding that is used for the page template** that part is inserted into.

(Think a `latin1` encoded HTML part that is inserted into an UTF-8 encoded page template via `tal:content="structure ..."`). 

`zope.pagetemplate` [attempts to handle meta tags](https://github.com/zopefoundation/zope.pagetemplate/blob/16ecfad512263ca75161ac16eeb404241a87d271/src/zope/pagetemplate/pagetemplatefile.py#L63-L74) when inserting markup with `structure`, by re-encoding the inserted markup and adjusting the rewriting the meta tag's `charset` accordingly.

If however the `<meta />` tag is broken and doesn't match [`zope.pagetemplate`'s regex](https://github.com/zopefoundation/zope.pagetemplate/blob/16ecfad512263ca75161ac16eeb404241a87d271/src/zope/pagetemplate/pagetemplatefile.py#L30-L33), the re-encoding doesn't take place and TAL / zope.pt chokes on the resulting mojibake, omitting parts of the document.

This addresses one specific case seen in the wild in a message created
with `Apple Mail (2.2104)`, where the semicolon (`;`) is missing between the MIME type and the charset declaration.

Example of this broken meta tag:
```html
<meta http-equiv="Content-Type" content="text/html charset=us-ascii">
```

@jone @deif

/cc @buchi