### PR TITLE
Mark inbound request with a marker interface.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- Mark inbound request with a marker interface.
+  [phgross]
+
 - Drop Plone 4.1 support.
   [phgross]
 

--- a/ftw/mail/inbound.py
+++ b/ftw/mail/inbound.py
@@ -8,6 +8,7 @@ from email.Utils import parseaddr
 from ftw.mail import exceptions
 from ftw.mail import utils
 from ftw.mail.interfaces import IEmailAddress
+from ftw.mail.interfaces import IInboundRequest
 from ftw.mail.interfaces import IMailInbound
 from ftw.mail.interfaces import IMailSettings
 from plone.dexterity.interfaces import IDexterityFTI
@@ -24,7 +25,9 @@ from zope.component import getUtility
 from zope.component import queryMultiAdapter
 from zope.component import queryUtility
 from zope.container.interfaces import INameChooser
+from zope.interface import alsoProvides
 from zope.interface import implements
+from zope.interface import noLongerProvides
 from zope.schema import getFields
 from zope.schema import getFieldsInOrder
 from zope.security.interfaces import IPermission
@@ -38,7 +41,10 @@ class MailInbound(BrowserView):
     implements(IMailInbound)
 
     def __call__(self):
-        return self.render()
+        alsoProvides(self.request, IInboundRequest)
+        result = self.render()
+        noLongerProvides(self.request, IInboundRequest)
+        return result
 
     def render(self):
         self.request.response.setHeader('Content-Type', 'text/plain')

--- a/ftw/mail/interfaces.py
+++ b/ftw/mail/interfaces.py
@@ -20,6 +20,11 @@ class IMailInbound(Interface):
         """
 
 
+class IInboundRequest(Interface):
+    """Marker interface for mail inbound requests.
+    """
+
+
 class IEmailAddress(Interface):
     """ Returns the email address for an object or the object an email
     email address


### PR DESCRIPTION
This allows special handling for example in default values or event handlers, when a mail gets created via mail-in.

@lukasgraf 