### PR TITLE
Fix setting defaults for choices with named vocabularies on inbound mails.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix setting defaults for choices with named vocabularies on inbound mails.
+  [phgross]
 
 
 2.4.0 (2016-07-19)

--- a/ftw/mail/inbound.py
+++ b/ftw/mail/inbound.py
@@ -191,6 +191,9 @@ def set_defaults(obj, container):
             # determining if a field is already set works as expected
             value = field.get(field.interface(aq_base(obj)))
             if value == field.missing_value or value is None:
+                # bind the field for choices with named vocabularies
+                field = field.bind(obj)
+
                 # No value is set, so we try to set the default value
                 # otherwise we set the missing value
                 default = queryMultiAdapter((


### PR DESCRIPTION
Bound field before accessing and setting the default value otherwise the zope.schema field validation will raise an `TypeError: argument of type 'function' is not iterable` when validating the aquired value.

