### PR TITLE
Remove newlines from headers, even inside encoded words.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,12 @@ Changelog
 2.4.1 (unreleased)
 ------------------
 
+- Remove newlines from headers, even inside encoded words.
+  decode_header from the email module splits the header before parsing
+  which breaks up encoded words and prevents them from being decoded.
+  https://github.com/python/cpython/blob/2.7/Lib/email/header.py#L78
+  [lknoepfel]
+
 - Move functionality to create mailed-in mails to an adapter to allow
   easier customization. [deiferni]
 

--- a/ftw/mail/tests/mails/newline_in_header.txt
+++ b/ftw/mail/tests/mails/newline_in_header.txt
@@ -1,0 +1,24 @@
+MIME-Version: 1.0
+Content-Type: text/plain; charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+To: to@example.org
+From: from@example.org
+Subject: =?iso-8859-1?Q?Email:_QP_B=FCschelisheimat
+ _/_Aktennotiz_vom_27?= =?iso-8859-1?Q?.02.2017?=
+Date: Thu, 01 Jan 1970 01:00:00 +0100
+Message-Id: <1>
+
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit,
+sed diam nonummy nibh euismod tincidunt ut laoreet dolore
+magna aliquam erat volutpat. Ut wisi enim ad minim veniam,
+quis nostrud exerci tation ullamcorper suscipit lobortis
+nisl ut aliquip ex ea commodo consequat.
+
+Duis autem vel eum iriure dolor in hendrerit in vulputate
+velit esse molestie consequat, vel illum dolore eu feugiat
+nulla facilisis at vero eros et accumsan et iusto odio
+dignissim qui blandit praesent luptatum zzril delenit augue
+duis dolore te feugait nulla facilisi.Lorem ipsum dolor sit
+amet, consectetuer adipiscing elit, sed diam nonummy nibh
+euismod tincidunt ut laoreet dolore magna aliquam erat
+volutpat.

--- a/ftw/mail/tests/test_utils.py
+++ b/ftw/mail/tests/test_utils.py
@@ -35,6 +35,8 @@ class TestUtils(unittest2.TestCase):
         self.from_header_with_quotes = email.message_from_string(msg_txt)
         msg_txt = open(os.path.join(here, 'mails', 'encoded_word_without_lwsp.txt'), 'r').read()
         self.encoded_word_without_lwsp = email.message_from_string(msg_txt)
+        msg_txt = open(os.path.join(here, 'mails', 'newline_in_header.txt'), 'r').read()
+        self.newline_in_header = email.message_from_string(msg_txt)
 
     def test_get_header(self):
         self.assertEquals('', utils.get_header(self.msg_empty, 'Subject'))
@@ -67,6 +69,12 @@ class TestUtils(unittest2.TestCase):
         self.assertEquals(
             'B\xc3\xa4rengrabenB\xc3\xa4rengraben <from@example.org>',
             utils.get_header(self.encoded_word_without_lwsp, 'From'))
+
+        # Also match mails with only \n newlines
+        self.assertEquals(
+            'Email: QP B\xc3\xbcschelisheimat   / Aktennotiz vom 27.02.2017',
+            utils.get_header(self.newline_in_header, 'Subject')
+        )
 
     def test_safe_decode_header_fixes_encoded_words_without_lwsp_in_middle(self):
         header = 'Foo =?utf-8?Q?B=C3=A4rengraben?=\r\n <from@example.org>'

--- a/ftw/mail/utils.py
+++ b/ftw/mail/utils.py
@@ -11,7 +11,7 @@ import re
 IMG_SRC_RE = re.compile(r'<img[^>]*?src="cid:([^"]*)', re.IGNORECASE|re.DOTALL)
 BODY_RE = re.compile(r'<body>(.*)</body>', re.IGNORECASE|re.DOTALL)
 APPLE_PARTIAL_ENCODING_RE = re.compile(r'^"(.*=\?.*\?=.*)"( <.*>)$')
-ENCODED_WORD_WITHOUT_LWSP = re.compile(r'(=\?.*?\?=)(\r\n)([ \t])')
+ENCODED_WORD_WITHOUT_LWSP = re.compile(r'(.*?)([\r\n]+)([ \t])')
 
 # Used to fix broken meta tags that confuse TAL
 # Largely copied from zope.pagetemplate.pagetemplatefile, adjusted for the
@@ -49,6 +49,8 @@ def safe_decode_header(value):
     # Fix up RFC 2047 encoded words separated by 'CRLF LWSP' (which is fine
     # according to the RFC) by replacing the CRLF with a SPACE so
     # decode_header can parse them correctly.
+    # Update: Remove CRLF and LF inside encoded words too, because decode_header
+    # splits lines before parsing the words.
     # This works around a bug in decode_header that has been fixed in 3.3.
     # See http://bugs.python.org/issue4491 and its duplicate.
     # Example:


### PR DESCRIPTION
decode_header from the email module splits the header before parsing which breaks up encoded words and prevents them from being decoded.
https://github.com/python/cpython/blob/2.7/Lib/email/header.py#L78

![screen shot 2017-05-17 at 15 46 52](https://cloud.githubusercontent.com/assets/1375745/26156939/2387869c-3b18-11e7-9074-683c3862d783.png)
This is a header which contains a newline (`\r\n` or `\n`) inside the encoded word. This results in this Subject:
![screen shot 2017-05-17 at 15 50 50](https://cloud.githubusercontent.com/assets/1375745/26157132/ab253e28-3b18-11e7-858d-222f4b717146.png)

I modified the `ENCODED_WORD_WITHOUT_LWSP` regex to match newlines inside words (`(=\?.*?\?=)`>`(.*?)` and match `\r\n`, `\n` and any other combination of those (`(\r\n)`>`([\r\n]+)`).

Extranet Ticket: https://extranet.4teamwork.ch/support/ai/tracker-teamraum/2/