### PR TITLE
Fix mail sorting in MailsTab view

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.5.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix sorting on dates for E-mails [njohner]
 
 
 2.5.2 (2017-07-11)

--- a/ftw/mail/configure.zcml
+++ b/ftw/mail/configure.zcml
@@ -69,6 +69,8 @@
         factory=".mail.SearchableTextExtender"
         />
 
+    <!-- Email date index -->
+    <adapter name="Date" factory=".indexers.Date" />
 
     <!-- ftw.mail.Mail default view -->
     <browser:page

--- a/ftw/mail/indexers.py
+++ b/ftw/mail/indexers.py
@@ -1,0 +1,11 @@
+from ftw.mail.mail import IMail
+from ftw.mail.utils import get_date_header
+from plone.indexer.decorator import indexer
+from DateTime import DateTime
+
+
+@indexer(IMail)
+def Date(object_, **kw):
+    """indexes the date of emails"""
+    email_date = object_.get_header("Date", True) or object_.created()
+    return email_date

--- a/ftw/mail/mail.py
+++ b/ftw/mail/mail.py
@@ -108,8 +108,9 @@ class Mail(Item):
     def _update_attachment_infos(self):
         self._attachment_infos = tuple(utils.get_attachments(self.msg))
 
-    def get_header(self, name):
+    def get_header(self, name, isdate=False):
         """Returns a header value from the mail message.
+        If it is a date, it returns a DateTime.
         This method caches the retrieved values.
         """
 
@@ -117,7 +118,11 @@ class Mail(Item):
             self._reset_header_cache()
 
         if name not in self._header_cache:
-            self._header_cache[name] = utils.get_header(self.msg, name)
+            if isdate:
+                ts = utils.get_date_header(self.msg, name)
+                self._header_cache[name] = DateTime(ts)
+            else:
+                self._header_cache[name] = utils.get_header(self.msg, name)
 
         return self._header_cache[name]
 

--- a/ftw/mail/mailtab.py
+++ b/ftw/mail/mailtab.py
@@ -25,7 +25,7 @@ def get_mail_header(field=None, isdate=False):
             return '<img src="%s" alt="%s" /> %s' % (
                 imgpath,
                 translate(_(u'attachment_icon_alt_text',
-                           default=u'Attachment'),
+                            default=u'Attachment'),
                           context=obj.REQUEST),
                 len(obj.attachment_infos))
 
@@ -68,8 +68,8 @@ class MailsTab(listing.CatalogListingView):
         {'column': 'Date',
          'column_title': _(u'label_mailstab_date',
                            default=u'Date Received'),
-         'transform': get_mail_header(field='Date', isdate=True),
-         'sortable': False},
+         'transform': helper.readable_date_time_text,
+         'sortable': True},
 
         {'column': 'Attachments',
          'column_title': _(u'label_mailstab_attachments',
@@ -81,4 +81,4 @@ class MailsTab(listing.CatalogListingView):
          'column_title': _(u'label_mailstab_creator',
                            default=u'Creator'),
          'transform': readable_author},
-        )
+    )

--- a/ftw/mail/mailtab.py
+++ b/ftw/mail/mailtab.py
@@ -17,12 +17,7 @@ def get_mail_header(field=None, isdate=False):
         obj = item.getObject()
 
         if isdate:
-            raw_date = obj.get_header(field)
-            raw_date = re.sub(r'\((.*)\)', '\g<1>', raw_date)
-            try:
-                date = DateTime(raw_date)
-            except SyntaxError:
-                return ''
+            date = obj.get_header(field, isdate)
             return helper.readable_date_time_text(item, date)
 
         elif field == 'attachments':

--- a/ftw/mail/upgrades/20171123113828_index_mail_date/upgrade.py
+++ b/ftw/mail/upgrades/20171123113828_index_mail_date/upgrade.py
@@ -1,0 +1,15 @@
+from ftw.upgrade import UpgradeStep
+
+
+class IndexMailDate(UpgradeStep):
+    """Update Date field in mail cache to new format
+    and index mail date in the Date index field
+    """
+
+    def __call__(self):
+        query = {'portal_type': 'ftw.mail.mail'}
+        msg = 'Update E-mail cache.'
+        for mail in self.objects(query, msg):
+            if "Date" in mail._header_cache:
+                del mail._header_cache["Date"]
+        self.catalog_reindex_objects(query, idxs=['Date'])


### PR DESCRIPTION
* Sorting by date in the MailsTab was broken in my.teamraum (https://github.com/4teamwork/my.teamraum/issues/290).
The reason was that the table gets sorted on the Date index which does not correspond to the E-mail date (sorting happens directly when querying the catalog).
The proposed fix is to index the E-mail date in the Date index. This would require an upgrade step to reindex all E-mails...

* The date representation in MailsTab could not handle certain date formats (see screen shots below before and after fix). Moreover it used its own parser instead of using the one provided by `mail.utils`. I changed this which allows:
    * To use the cache (we'd need to make sure dates aren't in the old format in the cache)
    * To have only one parser for mail header dates, and as it is a function, it can be tested...
![mails_tab_before](https://user-images.githubusercontent.com/7374243/32883555-0c90ff42-cab8-11e7-9da2-11c305ca95c0.png)
![mails_tab_after_fix](https://user-images.githubusercontent.com/7374243/32883558-0da0ffcc-cab8-11e7-9e86-3482b8b288c6.png)

* I would also propose to make the table sortable on any column, even ones that do not come from an index. I did this in two commits:
    * Sorting function : https://github.com/4teamwork/ftw.tabbedview/commit/3d19b5e613d705ff4e0bbcfe32c17229e46a5f55
    * Avoid invalid index in query: https://github.com/4teamwork/ftw.table/commit/b331680b14215534ebde12751a0dc6c1af969e23

![table_sort](https://user-images.githubusercontent.com/7374243/32885025-869f4362-cabc-11e7-8f9a-8dfcfe1b1f8f.gif)
