### PR TITLE
Fix treatment of invalid mail dates

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.5.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix treatment of invalid mail dates [njohner] 
 
 
 2.5.3 (2017-11-23)

--- a/ftw/mail/indexers.py
+++ b/ftw/mail/indexers.py
@@ -1,7 +1,5 @@
 from ftw.mail.mail import IMail
-from ftw.mail.utils import get_date_header
 from plone.indexer.decorator import indexer
-from DateTime import DateTime
 
 
 @indexer(IMail)

--- a/ftw/mail/mail.py
+++ b/ftw/mail/mail.py
@@ -120,7 +120,10 @@ class Mail(Item):
         if name not in self._header_cache:
             if isdate:
                 ts = utils.get_date_header(self.msg, name)
-                self._header_cache[name] = DateTime(ts)
+                if ts is not None:
+                    self._header_cache[name] = DateTime(ts)
+                else:
+                    self._header_cache[name] = ""
             else:
                 self._header_cache[name] = utils.get_header(self.msg, name)
 

--- a/ftw/mail/tests/test_mail.py
+++ b/ftw/mail/tests/test_mail.py
@@ -1,3 +1,4 @@
+from DateTime import DateTime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.mail.mail import IMail
@@ -30,6 +31,10 @@ class TestMailIntegration(TestCase):
             os.path.join(here, 'mails', 'attachment.txt'), 'r').read()
         self.msg_utf8 = open(
             os.path.join(here, 'mails', 'utf8.txt'), 'r').read()
+        self.msg_invalid_date = open(
+            os.path.join(here, 'mails', 'invalid_date.txt'), 'r').read()
+        self.msg_timezone_date = open(
+            os.path.join(here, 'mails', 'time_zone_dates.txt'), 'r').read()
 
     def test_adding(self):
         mail = create(Builder('mail'))
@@ -146,6 +151,13 @@ class TestMailIntegration(TestCase):
         mail = create(Builder('mail'))
         page = create(Builder('page').having(relatedItems=[IUUID(mail)]))
         self.assertTrue(page)
+
+    def test_date_parsing(self):
+        mail = create(Builder('mail').with_message(self.msg_invalid_date))
+        self.assertEquals("", mail.get_header('Date', True))
+        mail = create(Builder('mail').with_message(self.msg_timezone_date))
+        self.assertEquals(DateTime('28.08.2010 18:50:04 GMT+2'),
+                          mail.get_header('Date', True))
 
     # def test_special(self):
     #     here = os.path.dirname(__file__)

--- a/ftw/mail/tests/test_tab.py
+++ b/ftw/mail/tests/test_tab.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.mail.testing import FTW_MAIL_FUNCTIONAL_TESTING
+from ftw.table import helper
 from ftw.workspace.interfaces import IWorkspaceLayer
 from plone.registry.interfaces import IRegistry
 from unittest2 import TestCase
@@ -36,10 +37,11 @@ class TestMailTab(TestCase):
         mail_row = self.get_mails_tab_data().get('rows')[0]
         self.assertEquals('01.01.1970 01:00', mail_row.get('Date'))
 
-    def test_mail_invalid_date_results_in_empty_string(self):
-        create(Builder('mail').with_message(mail_asset('invalid_date')))
+    def test_mail_invalid_date_results_in_creation_date(self):
+        mail = create(Builder('mail').with_message(mail_asset('invalid_date')))
         mail_row = self.get_mails_tab_data().get('rows')[0]
-        self.assertEquals('', mail_row.get('Date'))
+        created = helper.readable_date_time_text(mail, mail.created())
+        self.assertEquals(created, mail_row.get('Date'))
 
     def test_mail_date_parsing_with_time_zone(self):
         create(Builder('mail').with_message(mail_asset('time_zone_dates')))

--- a/ftw/mail/tests/test_utils.py
+++ b/ftw/mail/tests/test_utils.py
@@ -94,7 +94,7 @@ class TestUtils(unittest2.TestCase):
         # an unparsable date header
         msg_txt = 'Date: at any time ...'
         msg = email.message_from_string(msg_txt)
-        self.assertEqual(0.0, utils.get_date_header(msg, 'Date'))
+        self.assertEqual(None, utils.get_date_header(msg, 'Date'))
 
     def test_get_payload(self):
         self.assertEquals('', utils.get_payload(self.msg_empty))

--- a/ftw/mail/utils.py
+++ b/ftw/mail/utils.py
@@ -89,7 +89,7 @@ def get_date_header(msg, name):
     timezone information.
     """
     value = get_header(msg, name)
-    ts = 0.0
+    ts = None
     try:
         ts = mktime_tz(parsedate_tz(value))
     except TypeError:


### PR DESCRIPTION
I fixed the tests for the mail dates, sorry about that.

* Changed the behaviour of `utils.get_date_header` to return `None` instead of `0` for invalid dates. `0` is a valid timestamp so should not be used for invalid dates.
* Adapted `mail.get_header` to return an empty string for an invalid date
* Adapted the tests:
    * MailTab does not show an empty string for an E-mail with invalid date, instead it shows the creation date. Testing this behavior
    * Added date parsing test in the E-mails to test valid and invalid dates