### PR TITLE
Fix upgrade for uninitialised header caches.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix upgrade when uninitialized header chaches are present. [deiferni]
 
 
 2.6.0 (2019-03-22)

--- a/ftw/mail/upgrades/20171123113828_index_mail_date/upgrade.py
+++ b/ftw/mail/upgrades/20171123113828_index_mail_date/upgrade.py
@@ -10,6 +10,6 @@ class IndexMailDate(UpgradeStep):
         query = {'portal_type': 'ftw.mail.mail'}
         msg = 'Update E-mail cache.'
         for mail in self.objects(query, msg):
-            if "Date" in mail._header_cache:
+            if hasattr(mail, "_header_cache") and "Date" in mail._header_cache:
                 del mail._header_cache["Date"]
         self.catalog_reindex_objects(query, idxs=['Date'])


### PR DESCRIPTION
The header cache may be uninitialized, so we have to check if it is present during the upgrade. We don't want to modify objects without a header cache thus we don't use the getter provided by the Mail class which would initialize uninintialized caches..