### PR TITLE
Fix buildout.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages
+from setuptools import setup
 import os
+
 
 version = '2.6.2.dev0'
 
@@ -51,7 +53,7 @@ setup(name='ftw.mail',
         'collective.dexteritytextindexer',
         'plone.directives.form',
         'ftw.upgrade >= 1.11.0',
-        'premailer',
+        'premailer < 3.7.0',
         ],
 
       tests_require=tests_require,

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -9,3 +9,5 @@ package-name = ftw.mail
 # Pin down ftw.calendar to fix test buildout
 # (version constraint in ftw.meeting via ftw.workspace)
 ftw.calendar = <3
+# soupsieve 2.0 has dropped support for Python 2.
+soupsieve = <2

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -11,3 +11,5 @@ package-name = ftw.mail
 ftw.calendar = <3
 # soupsieve 2.0 has dropped support for Python 2.
 soupsieve = <2
+# cachetools 4.0 has dropped support for Python 2.
+cachetools = <4


### PR DESCRIPTION
Buildout was failing because some dependencies were pulled which are no longer compatible with Python 2. We need to use older versions of those Python packages.