### PR TITLE
Improve header decoding.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Improve header decoding when encoded words are not separated by whitespace. [mbaechtold]
 
 
 2.6.1 (2019-07-08)

--- a/ftw/mail/tests/mails/encoded_word_not_separated_by_lwsp.txt
+++ b/ftw/mail/tests/mails/encoded_word_not_separated_by_lwsp.txt
@@ -1,0 +1,9 @@
+Mime-Version: 1.0
+Content-Type: multipart/mixed; boundary=908752978
+To: to@example.org
+From: from@example.org
+Subject: =?utf-8?Q?B=C3=A4ren?==?utf-8?Q?graben?=
+Date: Thu, 01 Jan 1970 01:00:00 +0100
+Message-Id: <1>
+
+The body of the message.

--- a/ftw/mail/tests/test_utils.py
+++ b/ftw/mail/tests/test_utils.py
@@ -38,6 +38,8 @@ class TestUtils(unittest2.TestCase):
         self.encoded_word_without_lwsp = email.message_from_string(msg_txt)
         msg_txt = open(os.path.join(here, 'mails', 'newline_in_header.txt'), 'r').read()
         self.newline_in_header = email.message_from_string(msg_txt)
+        msg_txt = open(os.path.join(here, 'mails', 'encoded_word_not_separated_by_lwsp.txt'), 'r').read()
+        self.sticky_encoded_words_in_subject = email.message_from_string(msg_txt)
 
     def test_get_header(self):
         self.assertEquals('', utils.get_header(self.msg_empty, 'Subject'))
@@ -82,6 +84,11 @@ class TestUtils(unittest2.TestCase):
         self.assertEquals(
             'Foo B\xc3\xa4rengraben <from@example.org>',
             utils.safe_decode_header(header))
+
+    def test_get_subject_header_with_sticky_encoded_words(self):
+        self.assertEquals(
+            'Bärengraben',
+            utils.get_header(self.sticky_encoded_words_in_subject, 'Subject'))
 
     def test_get_date_header(self):
         # a date header


### PR DESCRIPTION
When encoded words are not separated by whitespace, the decoded header used to contain some remainders of the encoded word prefix (=?charset?encoding?).

We fix this by adding a space between two "sticky" encoded words.

You may play with the regular expression at https://regex101.com/r/1aQcGs/7

![image](https://user-images.githubusercontent.com/28220/83888052-9b68a880-a749-11ea-9371-5f22ff9e2d9b.png)

Jira: https://4teamwork.atlassian.net/browse/GEVER-397