### PR TITLE
Pin "inflection" to < 0.5.

### DIFF
--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -13,3 +13,5 @@ ftw.calendar = <3
 soupsieve = <2
 # cachetools 4.0 has dropped support for Python 2.
 cachetools = <4
+# inflection 0.5 has dropped support for Python 2.
+inflection = <0.5


### PR DESCRIPTION
This is necessary as python 2 support has been removed as of 0.5.0. There seems to have been a new inflection release over the weekend.

Spiritual successor of https://github.com/4teamwork/ftw.mail/pull/55.