### PR TITLE
Pin cssutils to < 2.0.0 for python 2 support.

### DIFF
--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -13,3 +13,5 @@ ftw.calendar = <3
 soupsieve = <2
 # cachetools 4.0 has dropped support for Python 2.
 cachetools = <4
+# cssutils 2.0.0 has dropped support for Python 2.
+cssutils = <2


### PR DESCRIPTION
Newer versions require python >= 3.6. This will fix tests in master.