### PR TITLE
Handle missing filename for EML attachments.

### DIFF
--- a/ftw/mail/attachment.py
+++ b/ftw/mail/attachment.py
@@ -39,7 +39,7 @@ class AttachmentView(BrowserView):
 
         if attachment is not None:
             content_type = attachment.get_content_type()
-            filename = utils.get_filename(attachment)
+            filename = utils.get_filename(attachment, content_type)
             if filename is None:
                 raise NotFound
             # make sure we have a unicode string

--- a/ftw/mail/tests/test_utils.py
+++ b/ftw/mail/tests/test_utils.py
@@ -108,6 +108,9 @@ class TestUtils(unittest2.TestCase):
             [{'position': 4,
               'content-type': 'multipart/signed',
               'filename': 'smime.p7m'},
+             {'content-type': 'message/rfc822',
+              'filename': 'attachment.eml',
+              'position': 8},
              {'position': 12,
               'content-type': 'application/pdf',
               'filename': 'Testdatei.pdf'},
@@ -270,12 +273,16 @@ class TestUtils(unittest2.TestCase):
         self.assertIn('World', parts[1])
 
     def test_can_decode_encoded_multipart_attachments(self):
-        expected_attachments = [{
-            'content-type': 'message/delivery-status',
-            'filename': 'ATT74209.txt',
-            'position': 4,
-            'size': 0,
-            }]
+        expected_attachments = [
+            {'content-type': 'message/delivery-status',
+             'filename': 'ATT74209.txt',
+             'position': 4,
+             'size': 0},
+            {'content-type': 'message/rfc822',
+             'filename': 'attachment.eml',
+             'position': 10,
+             'size': 1783}
+            ]
         attachments = utils.get_attachments(self.multipart_encoded_with_attachments)
         self.assertEqual(expected_attachments, attachments)
 

--- a/ftw/mail/upgrades/20200608111326_rebuild_mail_cache_for_signed_multipart/upgrade.py
+++ b/ftw/mail/upgrades/20200608111326_rebuild_mail_cache_for_signed_multipart/upgrade.py
@@ -15,5 +15,7 @@ class RebuildMailCacheForSignedMultipart(UpgradeStep):
     def maybe_rebuild_attachment_infos(self, mail):
         for info in mail.attachment_infos:
             if info.get('content-type') == 'multipart/signed':
+                # In the future it should be avoided to overwrite the permanent
+                # attachment info cache. Gever uses it to store additional data.
                 mail._update_attachment_infos()
                 return

--- a/ftw/mail/upgrades/20210702104300_include_missing_em_ls_in_attachments/upgrade.py
+++ b/ftw/mail/upgrades/20210702104300_include_missing_em_ls_in_attachments/upgrade.py
@@ -1,0 +1,36 @@
+from ftw.mail import utils
+from ftw.upgrade import UpgradeStep
+import logging
+
+LOG = logging.getLogger('ftw.upgrade')
+
+
+class IncludeMissingEMLsInAttachments(UpgradeStep):
+    """Include missing emls in attachments.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        query = {'portal_type': 'ftw.mail.mail'}
+        for mail in self.objects(query, 'Include missing emls in attachments'):
+            self.add_missing_eml_attachments(mail)
+
+    def add_missing_eml_attachments(self, obj):
+        attachments = utils.get_attachments(obj.msg)
+        if len(attachments) == len(obj.attachment_infos):
+            return
+
+        info_list = list(obj.attachment_infos)
+        stored_positions = [each['position'] for each in info_list]
+
+        for attachment in attachments:
+            if attachment['position'] in stored_positions:
+                continue
+            if (attachment['filename'] != "attachment.eml" or
+                    attachment['content-type'] != "message/rfc822"):
+                LOG.warning(u"Found missing attachment that is not in-line eml"
+                            u"for {}. {}".format(obj.absolute_url(), attachment))
+                continue
+            info_list.append(attachment)
+        obj._attachment_infos = tuple(sorted(info_list, key=lambda x: x["position"]))

--- a/ftw/mail/utils.py
+++ b/ftw/mail/utils.py
@@ -153,7 +153,7 @@ def get_part_size(content_type, part):
 
 def parse_part(part):
     content_type = part.get_content_type()
-    filename = get_filename(part)
+    filename = get_filename(part, content_type)
     size = get_part_size(content_type, part)
     return content_type, filename, size
 
@@ -282,13 +282,20 @@ def get_position_for_cid(msg, cid):
     return None
 
 
-def get_filename(msg):
+def get_filename(msg, content_type=None):
     """Get the filename of a message (part)
     """
     filename = msg.get_filename(None)
 
     if filename is None:
         filename = msg.get_param('Name', None)
+
+    if filename is None:
+        # Outlook does not set filename for attached eml files
+        if content_type is None:
+            content_type = msg.get_content_type()
+        if content_type == "message/rfc822":
+            filename = "attachment.eml"
 
     # if the value is already decoded or another tuple
     # we just take the value and use the decode_header function


### PR DESCRIPTION
Outlook does not set the filename for attached EML files, so we need to handle this case explicitly.
Strangely it seems that some of our test files already reflected that fact and had such EML attachments. But IMO it seems correct.

For https://4teamwork.atlassian.net/browse/CA-2375