### PR TITLE
Fix download of mail attached to mail and use subject as filename when not otherwise provided

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2.7.2 (unreleased)
 ------------------
 
+- Fix download of mail attached to mail. [njohner]
 - Use mail subject as filename for eml attachments with missing filename. [njohner]
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use mail subject as filename for eml attachments with missing filename. [njohner]
 
 
 2.7.1 (2021-07-07)

--- a/ftw/mail/attachment.py
+++ b/ftw/mail/attachment.py
@@ -40,6 +40,12 @@ class AttachmentView(BrowserView):
         except UnicodeEncodeError:
             filename = filename.encode('utf-8', 'ignore')
 
-        self.request.response.setHeader('Content-Type', content_type)
-        self.request.response.setHeader('Content-Disposition', 'inline; filename=%s' % filename)
+        self.set_content_type(content_type, filename)
+        self.set_content_disposition(content_type, filename)
         return data
+
+    def set_content_type(self, content_type, filename):
+        self.request.response.setHeader('Content-Type', content_type)
+
+    def set_content_disposition(self, content_type, filename):
+        self.request.response.setHeader('Content-Disposition', 'inline; filename=%s' % filename)

--- a/ftw/mail/tests/mails/fwd_attachment_missing_filename.txt
+++ b/ftw/mail/tests/mails/fwd_attachment_missing_filename.txt
@@ -1,0 +1,44 @@
+Message-ID: <2>
+Date: Sat, 14 Feb 2009 00:31:30 +0100 (CET)
+MIME-Version: 1.0
+To: fwd.to@example.org
+From: fwd.from@example.org
+Subject: Fwd: Lorem Ipsum
+Content-Type: multipart/mixed;
+ boundary="------------050202060700000405010105"
+
+This is a multi-part message in MIME format.
+--------------050202060700000405010105
+Content-Type: text/plain; charset=UTF-8; format=flowed
+Content-Transfer-Encoding: 7bit
+
+
+
+--------------050202060700000405010105
+Content-Type: message/rfc822;
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment;
+
+To: to@example.org
+From: from@example.org
+Content-Type: text/plain; charset=UTF-8
+Message-Id: <1>
+Date: Thu, 01 Jan 1970 01:00:00 +0100
+MIME-Version: 1.0
+
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit,
+sed diam nonummy nibh euismod tincidunt ut laoreet dolore
+magna aliquam erat volutpat. Ut wisi enim ad minim veniam,
+quis nostrud exerci tation ullamcorper suscipit lobortis
+nisl ut aliquip ex ea commodo consequat.
+
+Duis autem vel eum iriure dolor in hendrerit in vulputate
+velit esse molestie consequat, vel illum dolore eu feugiat
+nulla facilisis at vero eros et accumsan et iusto odio
+dignissim qui blandit praesent luptatum zzril delenit augue
+duis dolore te feugait nulla facilisi.Lorem ipsum dolor sit
+amet, consectetuer adipiscing elit, sed diam nonummy nibh
+euismod tincidunt ut laoreet dolore magna aliquam erat
+volutpat.
+
+--------------050202060700000405010105--

--- a/ftw/mail/tests/test_utils.py
+++ b/ftw/mail/tests/test_utils.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from email.MIMEText import MIMEText
 from ftw.mail import utils
 from ftw.mail.tests import mails
+from zExceptions import NotFound
 import email
 import unittest2
 
@@ -440,6 +441,25 @@ Content-Transfer-Encoding: base64
                                        self.nested_referenced_image_attachment,
                                        'foo')
         self.assertIn('get_attachment?position=4', html)
+
+    def test_get_attachment_data_for_missing_attachment(self):
+        with self.assertRaises(NotFound):
+            utils.get_attachment_data(self.msg_fwd_attachment, 10)
+
+    def test_get_attachment_data_for_simple_attachment(self):
+        data, content_type, filename = utils.get_attachment_data(
+            self.msg_attachment, 1)
+        self.assertEqual(u'B\xfccher.txt', filename)
+        self.assertEqual('text/plain', content_type)
+        self.assertEqual('\xc3\xa4\xc3\xb6\xc3\x9c\n', data)
+
+    def test_get_attachment_data_for_attached_eml(self):
+        data, content_type, filename = utils.get_attachment_data(
+            self.msg_fwd_attachment, 2)
+        mail = email.message_from_string(data)
+        self.assertEqual('from@example.org', mail.get("from"))
+        self.assertEqual('to@example.org', mail.get("to"))
+        self.assertEqual('Lorem Ipsum', mail.get("Subject"))
 
 
 def test_suite():

--- a/ftw/mail/tests/test_utils.py
+++ b/ftw/mail/tests/test_utils.py
@@ -109,7 +109,7 @@ class TestUtils(unittest2.TestCase):
               'content-type': 'multipart/signed',
               'filename': 'smime.p7m'},
              {'content-type': 'message/rfc822',
-              'filename': 'attachment.eml',
+              'filename': 'Test signiert.eml',
               'position': 8},
              {'position': 12,
               'content-type': 'application/pdf',
@@ -279,7 +279,7 @@ class TestUtils(unittest2.TestCase):
              'position': 4,
              'size': 0},
             {'content-type': 'message/rfc822',
-             'filename': 'attachment.eml',
+             'filename': 'Status Report.eml',
              'position': 10,
              'size': 1783}
             ]

--- a/ftw/mail/tests/test_utils.py
+++ b/ftw/mail/tests/test_utils.py
@@ -33,6 +33,8 @@ class TestUtils(unittest2.TestCase):
             'attachment.txt')
         self.msg_fwd_attachment = mails.load_mail(
             'fwd_attachment.txt')
+        self.fwd_attachment_missing_filename = mails.load_mail(
+            'fwd_attachment_missing_filename.txt')
         self.msg_nested_attachments = mails.load_mail(
             'nested_attachments.txt')
         self.nested_referenced_image_attachment = mails.load_mail(
@@ -460,6 +462,16 @@ Content-Transfer-Encoding: base64
         self.assertEqual('from@example.org', mail.get("from"))
         self.assertEqual('to@example.org', mail.get("to"))
         self.assertEqual('Lorem Ipsum', mail.get("Subject"))
+
+    def test_get_attachment_data_for_attached_eml_with_missing_filename(self):
+        data, content_type, filename = utils.get_attachment_data(
+            self.fwd_attachment_missing_filename, 2)
+        self.assertEqual(u'[No Subject].eml', filename)
+        self.assertEqual('message/rfc822', content_type)
+
+        mail = email.message_from_string(data)
+        self.assertEqual('from@example.org', mail.get("from"))
+        self.assertEqual('to@example.org', mail.get("to"))
 
 
 def test_suite():

--- a/ftw/mail/utils.py
+++ b/ftw/mail/utils.py
@@ -240,13 +240,6 @@ def get_attachment_data(msg, pos):
     if not attachment:
         raise NotFound
 
-    # decode when it's necessary
-    filename = get_filename(attachment)
-    if not isinstance(filename, unicode):
-        filename = filename.decode('utf-8')
-    # remove line breaks from the filename
-    filename = re.sub(r'\s{1,}', ' ', filename)
-
     content_type = attachment.get_content_type()
     if content_type == 'message/rfc822':
         nested_messages = attachment.get_payload()
@@ -256,6 +249,13 @@ def get_attachment_data(msg, pos):
         data = nested_messages[0].as_string()
     else:
         data = attachment.get_payload(decode=1)
+
+    # decode when it's necessary
+    filename = get_filename(attachment, content_type)
+    if not isinstance(filename, unicode):
+        filename = filename.decode('utf-8')
+    # remove line breaks from the filename
+    filename = re.sub(r'\s{1,}', ' ', filename)
 
     return data, content_type, filename
 

--- a/ftw/mail/utils.py
+++ b/ftw/mail/utils.py
@@ -5,8 +5,9 @@ from email.header import decode_header
 from email.Utils import mktime_tz
 from email.Utils import parsedate_tz
 from ftw.mail import config
-import re
+from zExceptions import NotFound
 import email
+import re
 
 
 # a regular expression that matches src attributes of img tags containing a cid
@@ -237,7 +238,7 @@ def get_attachment_data(msg, pos):
             break
 
     if not attachment:
-        return None, '', ''
+        raise NotFound
 
     # decode when it's necessary
     filename = get_filename(attachment)

--- a/ftw/mail/utils.py
+++ b/ftw/mail/utils.py
@@ -295,7 +295,12 @@ def get_filename(msg, content_type=None):
         if content_type is None:
             content_type = msg.get_content_type()
         if content_type == "message/rfc822":
-            filename = "attachment.eml"
+            unwrapped = unwrap_attached_msg(msg)
+            subject = get_header(unwrapped, "Subject") or "attachment"
+            # long headers may contain line breaks with tabs.
+            # replace these by a space.
+            subject = subject.replace('\n\t', ' ')
+            filename = subject + ".eml"
 
     # if the value is already decoded or another tuple
     # we just take the value and use the decode_header function

--- a/ftw/mail/utils.py
+++ b/ftw/mail/utils.py
@@ -4,8 +4,11 @@ from DocumentTemplate.DT_Util import html_quote
 from email.header import decode_header
 from email.Utils import mktime_tz
 from email.Utils import parsedate_tz
+from ftw.mail import _
 from ftw.mail import config
 from zExceptions import NotFound
+from zope.globalrequest import getRequest
+from zope.i18n import translate
 import email
 import re
 
@@ -331,7 +334,10 @@ def get_filename(msg, content_type=None):
             content_type = msg.get_content_type()
         if content_type == "message/rfc822":
             unwrapped = unwrap_attached_msg(msg)
-            subject = get_header(unwrapped, "Subject") or "attachment"
+            default_subject = translate(
+                _(u'no_subject', default=u'[No Subject]'),
+                context=getRequest())
+            subject = get_header(unwrapped, "Subject") or default_subject
             # long headers may contain line breaks with tabs.
             # replace these by a space.
             subject = subject.replace('\n\t', ' ')


### PR DESCRIPTION
In Gever we had a method (`_get_attachment_data`) to get the data for a given attachment, which we use for extracting attachment. This method explicitly unwraps `message/rfc822` attachments (see https://github.com/4teamwork/opengever.core/blob/master/opengever/mail/mail.py#L295-L303). Download of `message/rfc822` attachments on the other hand was handled by the `AttachmentView` from this respository which did not include that specific treatment of `message/rfc822`, leading to downloaded mail attachments being wrapped in an empty mail. We correct this by:
- Moving the `_get_attachment_data` from Gever to ftw.mail
- Reusing the `get_attachment_data` method for the download of attachments (`AttachmentView`)

We also make a small improvement to use the Subject of the wrapped `message/rfc822` attachment as filename when the filename is not explicitly provided in the E-mail (this happens for outlook).

For https://4teamwork.atlassian.net/browse/CA-2375