### PR TITLE
Make title extraction from mail subject more decondig error-tolerant.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make title extraction from mail subject more decondig error-tolerant. [phgross]
 
 
 2.7.2 (2021-07-27)

--- a/ftw/mail/mail.py
+++ b/ftw/mail/mail.py
@@ -13,6 +13,7 @@ from plone.namedfile import field
 from plone.rfc822.interfaces import IPrimaryField
 from premailer import transform as premailer_transform
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.deprecation import deprecate
@@ -60,8 +61,8 @@ class Mail(Item):
         if subject:
             # long headers may contain line breaks with tabs.
             # replace these by a space.
-            subject = subject.replace('\n\t', ' ')
-            self._title = subject.decode('utf8')
+            subject = safe_unicode(subject).replace(u'\n\t', u' ')
+            self._title = subject
 
     @property
     def message(self):

--- a/ftw/mail/tests/mails/msg_subject_encoding.txt
+++ b/ftw/mail/tests/mails/msg_subject_encoding.txt
@@ -1,0 +1,11 @@
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary=16347299321.fF1feCe.22
+Content-Transfer-Encoding: 7bit
+To: =?iso-8859-1?q?Friedrich_H=F6lderlin?= <to@example.org>
+From: from@example.org
+Subject: Re: Test Subject =?UTF-8?B?TcOpZGljYWxl?=,
+ =?UTF-8?B?IFLDqXNlYXU=?= testtesttes =?UTF-8?B?bmV1Y2jDonRlbG9pcw==?=, =?UTF-8?B?IE5ldWNow6J0ZWw=?= - Test
+Date: Wed, 28 Aug 2010 INVALID 18:50:04
+Message-Id: <1>
+
+Text

--- a/ftw/mail/tests/test_mail.py
+++ b/ftw/mail/tests/test_mail.py
@@ -38,6 +38,8 @@ class TestMailIntegration(TestCase):
             os.path.join(here, 'mails', 'time_zone_dates.txt'), 'r').read()
         self.msg_fwd_attachment = open(
             os.path.join(here, 'mails', 'fwd_attachment.txt'), 'r').read()
+        self.msg_subject_encoding = open(
+            os.path.join(here, 'mails', 'msg_subject_encoding.txt'), 'r').read()
 
     def test_adding(self):
         mail = create(Builder('mail'))
@@ -177,6 +179,12 @@ class TestMailIntegration(TestCase):
         mail = create(Builder('mail').with_message(self.msg_timezone_date))
         self.assertEquals(DateTime('28.08.2010 18:50:04 GMT+2'),
                           mail.get_header('Date', True))
+
+    def test_replace_invalid_characters_from_the_subject_when_setting_the_title(self):
+        mail = create(Builder('mail').with_message(self.msg_subject_encoding))
+        self.assertEquals(
+            u'Re: Test Subject M\xe9dicaleQ1|\x04\ufffdK\x0e\ufffd\u0355\ufffd\ufffd testtesttes neuch\xe2telois - Test',
+            mail.title)
 
     # def test_special(self):
     #     here = os.path.dirname(__file__)


### PR DESCRIPTION
By using plones `safe_unicode` to decode the subject, invalid characters are replaced with the replacement character instead of aborting with an UnicodeDecodeError.

For [CA-3068](https://4teamwork.atlassian.net/browse/CA-3068)