### PR TITLE
Handle cropped filenames of attachments.

### DIFF
--- a/ftw/mail/tests/mails/cropped_filename_attachment.txt
+++ b/ftw/mail/tests/mails/cropped_filename_attachment.txt
@@ -1,0 +1,23 @@
+Mime-Version: 1.0
+Content-Type: multipart/mixed; boundary=908752978
+To: to@example.org
+From: from@example.org
+Subject: Attachment Test
+Date: Thu, 01 Jan 1970 01:00:00 +0100
+Message-Id: <1>
+
+
+--908752978
+Content-Type: application/octet-stream;
+ name*0*=UTF-8''Lorem ipsum dolor sit ametx consetetur sadipscing elitrx sedd;
+ name*1*=Lorem ipsum dolor sit ametx consetetur sadipscing.txt;
+ name="Lorem ipsum dolor sit ametx consetetur sadipscing elitrx sed digam..."
+Content-Disposition: attachment;
+ filename*0*=UTF-8''Lorem ipsum dolor sit ametx consetetur sadipscing elitrx ;
+ filename*1*=sedd Lorem ipsum dolor sit ametx consetetur sadipscing.txt;
+ filename="Lorem ipsum dolor sit ametx consetetur sadipscing elitrx sed digam..."
+Content-Transfer-Encoding: base64
+
+w6TDtsOcCg==
+
+--908752978--

--- a/ftw/mail/tests/test_utils.py
+++ b/ftw/mail/tests/test_utils.py
@@ -39,6 +39,8 @@ class TestUtils(unittest2.TestCase):
             'nested_attachments.txt')
         self.nested_referenced_image_attachment = mails.load_mail(
             'nested_referenced_image_attachment.txt')
+        self.cropped_filename_attachment = mails.load_mail(
+            'cropped_filename_attachment.txt')
         self.msg_multiple_html_parts = mails.load_mail(
             'multiple_html_parts.txt')
         self.multipart_encoded_with_attachments = mails.load_mail(
@@ -472,6 +474,14 @@ Content-Transfer-Encoding: base64
         mail = email.message_from_string(data)
         self.assertEqual('from@example.org', mail.get("from"))
         self.assertEqual('to@example.org', mail.get("to"))
+
+    def test_get_attachment_data_for_attachment_with_cropped_filename(self):
+        self.assertEquals(
+            [{'position': 1,
+              'size': 7,
+              'content-type': 'application/octet-stream',
+              'filename': 'Lorem ipsum dolor sit ametx consetetur sadipscing elitrx seddLorem ipsum dolor sit ametx consetetur sadipscing.txt'}],
+            utils.get_attachments(self.cropped_filename_attachment))
 
 
 def test_suite():

--- a/ftw/mail/utils.py
+++ b/ftw/mail/utils.py
@@ -343,6 +343,17 @@ def get_filename(msg, content_type=None):
             subject = subject.replace('\n\t', ' ')
             filename = subject + ".eml"
 
+    # In some cases the content-disposition header contains multiple name
+    # attributes and pythons email module returns a cropped name without an
+    # extension when using the get_filename method. Therefore we handle this
+    # case explicit as a fallback.
+    if filename and filename.endswith('...'):
+        filenames = [
+            param[1] for param in msg.get_params() if param[0] == 'name']
+
+        if len(filenames) > 1:
+            filename = filenames[-1]
+
     # if the value is already decoded or another tuple
     # we just take the value and use the decode_header function
     if isinstance(filename, tuple):

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -17,6 +17,8 @@ soupsieve = <2
 cachetools = <4
 # cssutils 2.0.0 has dropped support for Python 2.
 cssutils = <2
+# cssselect 1.2.0 has dropped support for Python 2.
+cssselect = <1.2.0
 # XlsxWriter 3.0.0 has dropped support for Python 2.
 XlsxWriter = <3
 # Mako python 2.7 version


### PR DESCRIPTION
In some cases the content-disposition header contains multiple name attributes and pythons email module returns a cropped name without an extension when using the get_filename method. Therefore we handle this case explicit as a fallback, if the filename endswith `...`.

For [CA-4849](https://4teamwork.atlassian.net/browse/CA-4849)