### PR TITLE
Handle more cases of cropped attachment filenames

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Handle more cases of cropped attachment filenames. [lgraf]
 
 
 2.7.4 (2022-11-15)

--- a/ftw/mail/tests/mails/cropped_filename_attachment2.txt
+++ b/ftw/mail/tests/mails/cropped_filename_attachment2.txt
@@ -1,0 +1,20 @@
+Mime-Version: 1.0
+Content-Type: multipart/mixed; boundary=908752978
+To: to@example.org
+From: from@example.org
+Subject: Attachment Test
+Date: Thu, 01 Jan 1970 01:00:00 +0100
+Message-Id: <1>
+
+
+--908752978
+Content-Type: application/octet-stream; name="My
+ title is cropped in some places.pdf"
+Content-Disposition: attachment; filename*0="My
+ title is cropped in some places"; filename*1=".pdf"; filename="My
+ title is cropped..."
+Content-Transfer-Encoding: base64
+
+w6TDtsOcCg==
+
+--908752978--

--- a/ftw/mail/tests/test_utils.py
+++ b/ftw/mail/tests/test_utils.py
@@ -41,6 +41,8 @@ class TestUtils(unittest2.TestCase):
             'nested_referenced_image_attachment.txt')
         self.cropped_filename_attachment = mails.load_mail(
             'cropped_filename_attachment.txt')
+        self.cropped_filename_attachment2 = mails.load_mail(
+            'cropped_filename_attachment2.txt')
         self.msg_multiple_html_parts = mails.load_mail(
             'multiple_html_parts.txt')
         self.multipart_encoded_with_attachments = mails.load_mail(
@@ -482,6 +484,14 @@ Content-Transfer-Encoding: base64
               'content-type': 'application/octet-stream',
               'filename': 'Lorem ipsum dolor sit ametx consetetur sadipscing elitrx seddLorem ipsum dolor sit ametx consetetur sadipscing.txt'}],
             utils.get_attachments(self.cropped_filename_attachment))
+
+    def test_get_attachment_data_for_attachment_with_cropped_filename_variant2(self):
+        self.assertEquals(
+            [{'position': 1,
+              'size': 7,
+              'content-type': 'application/octet-stream',
+              'filename': 'My\n title is cropped in some places.pdf'}],
+            utils.get_attachments(self.cropped_filename_attachment2))
 
 
 def test_suite():

--- a/ftw/mail/tests/test_utils.py
+++ b/ftw/mail/tests/test_utils.py
@@ -490,7 +490,7 @@ Content-Transfer-Encoding: base64
             [{'position': 1,
               'size': 7,
               'content-type': 'application/octet-stream',
-              'filename': 'My\n title is cropped in some places.pdf'}],
+              'filename': 'My title is cropped in some places.pdf'}],
             utils.get_attachments(self.cropped_filename_attachment2))
 
 

--- a/ftw/mail/utils.py
+++ b/ftw/mail/utils.py
@@ -353,6 +353,8 @@ def get_filename(msg, content_type=None):
 
         if len(filenames) >= 1:
             filename = filenames[-1]
+            if isinstance(filename, basestring):
+                filename = filename.replace('\n', '')
 
     # if the value is already decoded or another tuple
     # we just take the value and use the decode_header function

--- a/ftw/mail/utils.py
+++ b/ftw/mail/utils.py
@@ -351,7 +351,7 @@ def get_filename(msg, content_type=None):
         filenames = [
             param[1] for param in msg.get_params() if param[0] == 'name']
 
-        if len(filenames) > 1:
+        if len(filenames) >= 1:
             filename = filenames[-1]
 
     # if the value is already decoded or another tuple


### PR DESCRIPTION
Handle more cases of cropped attachment filenames:

The existing condition that was used to try and avoid picking a cropped filename from the `Content-Disposition` / `Content-Type` headers was too conservative.

It only picked one of the unmangled names when multiple were present, but we've seen messages in the wild that contain exactly one unmangled filename in the 'name' param of the Content-Type header (in addition to a cropped one in the `Content-Disposition` header).

This change attempts to widen the scope of this fallback to include that case.

For [CA-5287](https://4teamwork.atlassian.net/browse/CA-5287)