### PR TITLE
Improve attachment filename extraction

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Further improve attachment filename extraction. [njohner]
 
 
 2.7.5 (2023-01-31)

--- a/ftw/mail/tests/mails/cropped_filename_attachment.txt
+++ b/ftw/mail/tests/mails/cropped_filename_attachment.txt
@@ -13,8 +13,8 @@ Content-Type: application/octet-stream;
  name*1*=Lorem ipsum dolor sit ametx consetetur sadipscing.txt;
  name="Lorem ipsum dolor sit ametx consetetur sadipscing elitrx sed digam..."
 Content-Disposition: attachment;
- filename*0*=UTF-8''Lorem ipsum dolor sit ametx consetetur sadipscing elitrx ;
- filename*1*=sedd Lorem ipsum dolor sit ametx consetetur sadipscing.txt;
+ filename*0*=UTF-8''Lorem ipsum dolor sit ametx consetetur sadipscing elitrx sedd;
+ filename*1*=Lorem ipsum dolor sit ametx consetetur sadipscing.txt;
  filename="Lorem ipsum dolor sit ametx consetetur sadipscing elitrx sed digam..."
 Content-Transfer-Encoding: base64
 

--- a/ftw/mail/tests/mails/filename_attachment_with_umlauts.txt
+++ b/ftw/mail/tests/mails/filename_attachment_with_umlauts.txt
@@ -1,0 +1,22 @@
+Mime-Version: 1.0
+Content-Type: multipart/mixed; boundary=908752978
+To: to@example.org
+From: from@example.org
+Subject: Attachment Test
+Date: Thu, 01 Jan 1970 01:00:00 +0100
+Message-Id: <1>
+
+
+--908752978
+Content-Type:
+ application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;
+ name*=UTF-8''230228_Besondere%20Leistungen_M%C3%B6gliche%20F%C3%A4lle.xlsx;
+ name="230228_Besondere Leistungen_Mogliche Falle.xlsx"
+Content-Disposition: attachment;
+ filename*0*=UTF-8''230228_Besondere%20Leistungen_M%C3%B6gliche%20F%C3%A4lle.;
+ filename*1*=xlsx; filename="230228_Besondere Leistungen_Mogliche Falle.xlsx"
+Content-Transfer-Encoding: base64
+
+w6TDtsOcCg==
+
+--908752978--

--- a/ftw/mail/tests/test_utils.py
+++ b/ftw/mail/tests/test_utils.py
@@ -43,6 +43,8 @@ class TestUtils(unittest2.TestCase):
             'cropped_filename_attachment.txt')
         self.cropped_filename_attachment2 = mails.load_mail(
             'cropped_filename_attachment2.txt')
+        self.filename_attachment_with_umlauts = mails.load_mail(
+            'filename_attachment_with_umlauts.txt')
         self.msg_multiple_html_parts = mails.load_mail(
             'multiple_html_parts.txt')
         self.multipart_encoded_with_attachments = mails.load_mail(
@@ -492,6 +494,14 @@ Content-Transfer-Encoding: base64
               'content-type': 'application/octet-stream',
               'filename': 'My title is cropped in some places.pdf'}],
             utils.get_attachments(self.cropped_filename_attachment2))
+
+    def test_get_attachment_data_for_attachment_umlauts_in_filenames(self):
+        self.assertEquals(
+            [{'position': 1,
+              'size': 7,
+              'content-type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+              'filename': '230228_Besondere Leistungen_M\xc3\xb6gliche F\xc3\xa4lle.xlsx'}],
+            utils.get_attachments(self.filename_attachment_with_umlauts))
 
 
 def test_suite():

--- a/ftw/mail/utils.py
+++ b/ftw/mail/utils.py
@@ -346,7 +346,8 @@ def get_filename(msg, content_type=None):
     # case explicit as a fallback.
     if filename and filename.endswith('...'):
         filenames = [
-            param[1] for param in msg.get_params() if param[0].lower() == 'name']
+            param[1] for param in msg.get_params(header='content-disposition')
+            if param[0].lower() == 'filename']
 
         if len(filenames) >= 1:
             filename = filenames[-1]

--- a/ftw/mail/utils.py
+++ b/ftw/mail/utils.py
@@ -326,9 +326,6 @@ def get_filename(msg, content_type=None):
     filename = msg.get_filename(None)
 
     if filename is None:
-        filename = msg.get_param('Name', None)
-
-    if filename is None:
         # Outlook does not set filename for attached eml files
         if content_type is None:
             content_type = msg.get_content_type()

--- a/ftw/mail/utils.py
+++ b/ftw/mail/utils.py
@@ -346,7 +346,7 @@ def get_filename(msg, content_type=None):
     # case explicit as a fallback.
     if filename and filename.endswith('...'):
         filenames = [
-            param[1] for param in msg.get_params() if param[0] == 'name']
+            param[1] for param in msg.get_params() if param[0].lower() == 'name']
 
         if len(filenames) >= 1:
             filename = filenames[-1]


### PR DESCRIPTION
We were already handling the case where filename returned by `msg.get_filename()` returned a cropped version of the filename. In that case we took the filename from the last `filename` parameter of the `content-disposition` headers. It now turns out that sometimes `msg.get_filename()` returns a normalized version of the filename, e.g. without umlauts. This is also not what we want and using the last `filename` parameter of the `content-disposition` headers would also fix the issue. So it seems we can always take the last one when there are several.

Note that I changed/fixed a few other things:
- We pretended to look at the  `content-disposition` header when we were actually looking at the `content-type` header.
- We now search for the "filename" parameter in the header case-insensitive. This is also what python's `Message.get_param` does.

For https://4teamwork.atlassian.net/browse/CA-5456