### PR TITLE
Fix unicode decode error in mail attachment filename extraction.

### DIFF
--- a/ftw/mail/tests/mails/filename_attachment_with_umlauts2.txt
+++ b/ftw/mail/tests/mails/filename_attachment_with_umlauts2.txt
@@ -1,0 +1,20 @@
+Mime-Version: 1.0
+Content-Type: multipart/mixed; boundary=908752978
+Content-Transfer-Encoding: 7bit
+To: to@example.org
+From: from@example.org
+Subject: Attachment Test
+Date: Thu, 01 Jan 1970 01:00:00 +0100
+Message-Id: <1>
+
+
+--908752978
+Content-ID: <16136533043.c18D.10630@mut.4teamwork.ch>
+Content-Type:
+ application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+Content-Disposition: attachment; filename="OSUniLU_Final08_Tab_Für4tw.xlsx"
+Content-Transfer-Encoding: base64
+
+w6TDtsOcCg==
+
+--908752978--

--- a/ftw/mail/tests/test_utils.py
+++ b/ftw/mail/tests/test_utils.py
@@ -45,6 +45,8 @@ class TestUtils(unittest2.TestCase):
             'cropped_filename_attachment2.txt')
         self.filename_attachment_with_umlauts = mails.load_mail(
             'filename_attachment_with_umlauts.txt')
+        self.filename_attachment_with_umlauts2 = mails.load_mail(
+            'filename_attachment_with_umlauts2.txt')
         self.msg_multiple_html_parts = mails.load_mail(
             'multiple_html_parts.txt')
         self.multipart_encoded_with_attachments = mails.load_mail(
@@ -495,13 +497,21 @@ Content-Transfer-Encoding: base64
               'filename': 'My title is cropped in some places.pdf'}],
             utils.get_attachments(self.cropped_filename_attachment2))
 
-    def test_get_attachment_data_for_attachment_umlauts_in_filenames(self):
+    def test_get_attachment_data_for_attachment_with_umlauts_in_filenames(self):
         self.assertEquals(
             [{'position': 1,
               'size': 7,
               'content-type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
               'filename': '230228_Besondere Leistungen_M\xc3\xb6gliche F\xc3\xa4lle.xlsx'}],
             utils.get_attachments(self.filename_attachment_with_umlauts))
+
+    def test_get_attachment_data_for_attachment_with_umlauts_in_filenames_variant2(self):
+        self.assertEquals(
+            [{'position': 1,
+              'size': 7,
+              'content-type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+              'filename': 'OSUniLU_Final08_Tab_F\xc3\xbcr4tw.xlsx'}],
+            utils.get_attachments(self.filename_attachment_with_umlauts2))
 
 
 def test_suite():

--- a/ftw/mail/utils.py
+++ b/ftw/mail/utils.py
@@ -6,7 +6,7 @@ from email.Utils import mktime_tz
 from email.Utils import parsedate_tz
 from ftw.mail import _
 from ftw.mail import config
-from future.backports.email import utils
+from email import utils
 from zExceptions import NotFound
 from zope.globalrequest import getRequest
 from zope.i18n import translate


### PR DESCRIPTION
I still do not understand why we get a unicode decode error in the unquote method from `future.backports.email.utils` and not from `email.utils`, but that's what it is 🤷 . Before https://github.com/4teamwork/ftw.mail/pull/72, this is what happened in the background, because we were using `msg.get_filename(None)`, which itself calls `email.utils.unquote`, so I basically switch back to using that variant of the `unquote` method.

For [CA-5456](https://4teamwork.atlassian.net/browse/CA-5456)

Will fix:
- https://sentry.4teamwork.ch/organizations/sentry/issues/108094
- https://sentry.4teamwork.ch/organizations/sentry/issues/108093
- https://sentry.4teamwork.ch/organizations/sentry/issues/108095
- https://sentry.4teamwork.ch/organizations/sentry/issues/108103
- https://sentry.4teamwork.ch/organizations/sentry/issues/108137